### PR TITLE
Replace python-Levenshtein with RapidFuzz

### DIFF
--- a/mmocr/core/evaluation/ocr_metric.py
+++ b/mmocr/core/evaluation/ocr_metric.py
@@ -1,7 +1,7 @@
 import re
 from difflib import SequenceMatcher
 
-import Levenshtein
+from rapidfuzz import string_metric
 
 
 def cal_true_positive_char(pred, gt):
@@ -61,8 +61,8 @@ def count_matches(pred_texts, gt_texts):
         match_res['gt_word_num'] += 1
 
         # normalized edit distance
-        edit_dist = Levenshtein.distance(pred_text_lower_ignore,
-                                         gt_text_lower_ignore)
+        edit_dist = string_metric.levenshtein(pred_text_lower_ignore,
+                                              gt_text_lower_ignore)
         norm_ed = float(edit_dist) / max(1, len(gt_text_lower_ignore),
                                          len(pred_text_lower_ignore))
         norm_ed_sum += norm_ed

--- a/requirements/readthedocs.txt
+++ b/requirements/readthedocs.txt
@@ -7,7 +7,7 @@ numpy
 Polygon3
 pyclipper
 pycocotools
-python-Levenshtein
+rapidfuzz
 scikit-image
 scipy
 shapely

--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -1,10 +1,9 @@
 imgaug
-Levenshtein
 lmdb
 matplotlib
 numba>=0.45.1
 numpy
-python-Levenshtein
+rapidfuzz
 scikit-image
 six
 terminaltables

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,7 +20,7 @@ line_length = 79
 multi_line_output = 0
 known_standard_library = setuptools
 known_first_party = mmdet,mmocr
-known_third_party = Levenshtein,PIL,Polygon,cv2,imgaug,lmdb,matplotlib,mmcv,numpy,pyclipper,pycocotools,pytest,scipy,shapely,skimage,titlecase,torch,torchvision
+known_third_party = PIL,Polygon,cv2,imgaug,lmdb,matplotlib,mmcv,numpy,pyclipper,pycocotools,pytest,rapidfuzz,scipy,shapely,skimage,titlecase,torch,torchvision
 no_lines_before = STDLIB,LOCALFOLDER
 default_section = THIRDPARTY
 


### PR DESCRIPTION
This PR replaces python-Levenshtein with RapidFuzz (disclaimer: I am the author) for the following reasons:
- python-Levenshtein is the only GPL licensed dependency (RapidFuzz is MIT licensed)
- RapidFuzz provides wheels, while this currently requires workarounds like the `Levenshtein` library for python-Levenshtein (This will probably get better once a new maintainer for python-Levenshtein is found)
- The Levenshtein implementation in RapidFuzz is a lot faster:
<img src="https://raw.githubusercontent.com/maxbachmann/RapidFuzz/089b5a74d0bdb3b2ee6f4fa36102eaece206a417/docs/img/uniform_levenshtein.svg?sanitize=true">