### PR TITLE
Add support for numpy array inference

### DIFF
--- a/mmocr/apis/inference.py
+++ b/mmocr/apis/inference.py
@@ -18,6 +18,8 @@ def model_inference(model, img):
         result (dict): Detection results.
     """
 
+    assert isinstance(img, str) or isinstance(img, np.ndarray)
+
     cfg = model.cfg
     device = next(model.parameters()).device  # model device
 

--- a/mmocr/apis/inference.py
+++ b/mmocr/apis/inference.py
@@ -3,8 +3,8 @@ import torch
 from mmcv.ops import RoIPool
 from mmcv.parallel import collate, scatter
 
-from mmdet.datasets.pipelines import Compose
 from mmdet.datasets import replace_ImageToTensor
+from mmdet.datasets.pipelines import Compose
 
 
 def model_inference(model, img):
@@ -37,7 +37,7 @@ def model_inference(model, img):
     else:
         # add information into dict
         data = dict(img_info=dict(filename=img), img_prefix=None)
-    
+
     # build the data pipeline
     data = test_pipeline(data)
     data = collate([data], samples_per_gpu=1)

--- a/mmocr/apis/inference.py
+++ b/mmocr/apis/inference.py
@@ -18,7 +18,7 @@ def model_inference(model, img):
         result (dict): Detection results.
     """
 
-    assert isinstance(img, str) or isinstance(img, np.ndarray)
+    assert isinstance(img, (str, np.ndarray))
 
     cfg = model.cfg
     device = next(model.parameters()).device  # model device

--- a/tests/test_apis/test_model_inference.py
+++ b/tests/test_apis/test_model_inference.py
@@ -6,11 +6,18 @@ import pytest
 
 from mmdet.apis import init_detector
 from mmocr.apis.inference import model_inference
+from mmcv.image import imread
 
+@pytest.fixture
+def project_dir():
+    return os.path.abspath(os.path.dirname(os.path.dirname(__file__)))
 
-def test_model_inference():
+@pytest.fixture
+def sample_img_path(project_dir):
+    return os.path.join(project_dir, '../demo/demo_text_recog.jpg')
 
-    project_dir = os.path.abspath(os.path.dirname(os.path.dirname(__file__)))
+@pytest.fixture
+def sarnet_model(project_dir):
     print(project_dir)
     config_file = os.path.join(
         project_dir,
@@ -37,10 +44,17 @@ def test_model_inference():
     if model.cfg.data.test['type'] == 'ConcatDataset':
         model.cfg.data.test.pipeline = model.cfg.data.test['datasets'][
             0].pipeline
-
-    img = os.path.join(project_dir, '../demo/demo_text_recog.jpg')
+    
+    return model
+    
+def test_model_inference_image_path(sample_img_path, sarnet_model):
 
     with pytest.raises(AssertionError):
-        model_inference(model, 1)
+        model_inference(sarnet_model, 1)
 
-    model_inference(model, img)
+    model_inference(sarnet_model, sample_img_path)
+
+
+def test_model_inference_numpy_ndarray(sample_img_path, sarnet_model):
+    img = imread(sample_img_path)
+    model_inference(sarnet_model, img)

--- a/tests/test_apis/test_model_inference.py
+++ b/tests/test_apis/test_model_inference.py
@@ -3,18 +3,21 @@ import shutil
 import urllib
 
 import pytest
+from mmcv.image import imread
 
 from mmdet.apis import init_detector
 from mmocr.apis.inference import model_inference
-from mmcv.image import imread
+
 
 @pytest.fixture
 def project_dir():
     return os.path.abspath(os.path.dirname(os.path.dirname(__file__)))
 
+
 @pytest.fixture
 def sample_img_path(project_dir):
     return os.path.join(project_dir, '../demo/demo_text_recog.jpg')
+
 
 @pytest.fixture
 def sarnet_model(project_dir):
@@ -44,9 +47,10 @@ def sarnet_model(project_dir):
     if model.cfg.data.test['type'] == 'ConcatDataset':
         model.cfg.data.test.pipeline = model.cfg.data.test['datasets'][
             0].pipeline
-    
+
     return model
-    
+
+
 def test_model_inference_image_path(sample_img_path, sarnet_model):
 
     with pytest.raises(AssertionError):


### PR DESCRIPTION
 * mmocr.apis.model_inference now supports a numpy array as input
 * Fixes #73 