### PR TITLE
increase the number of candidates for DBNet to 3000

### DIFF
--- a/mmocr/models/textdet/postprocess/wrapper.py
+++ b/mmocr/models/textdet/postprocess/wrapper.py
@@ -186,7 +186,7 @@ def db_decode(preds,
               min_text_score=0.3,
               min_text_width=5,
               unclip_ratio=1.5,
-              max_candidates=1000):
+              max_candidates=3000):
     """Decoding predictions of DbNet to instances. This is partially adapted
     from https://github.com/MhLiao/DB.
 


### PR DESCRIPTION
This solves the issue when dealing with documents with a large number of words per-page.
**Note that i haven't test the effect of increasing the candidates on whether it affects the prediction fps or not.**
@jeffreykuang i am not signing the `CLA` license, so close this pull, and a pull under your name for this commit.
```
max_candidates=3000):
```