### PR TITLE
Update base.py

### DIFF
--- a/mmocr/models/textrecog/recognizer/base.py
+++ b/mmocr/models/textrecog/recognizer/base.py
@@ -75,7 +75,7 @@ class BaseRecognizer(nn.Module, metaclass=ABCMeta):
                 The outer list indicates images in a batch.
         """
         if isinstance(imgs, list):
-            assert len(imgs) == len(img_metas)
+            # assert len(imgs) == len(img_metas)
             assert len(imgs) > 0
             assert imgs[0].size(0) == 1, ('aug test does not support '
                                           f'inference with batch size '


### PR DESCRIPTION
Resolving Bug which arises when you are trying to perform Recognition Inference on an Image with a single Character in it. This fixed the bug for me and has not shown any other consequences on normal inference.