### PR TITLE
Add things from "import *" to __all__

### DIFF
--- a/mmocr/core/__init__.py
+++ b/mmocr/core/__init__.py
@@ -3,14 +3,14 @@ from .mask import extract_boundary, points2boundary, seg2boundary
 from .visualize import (det_recog_show_result, imshow_edge_node,
                         imshow_pred_boundary, imshow_text_char_boundary,
                         imshow_text_label, overlay_mask_img, show_feature,
-                        show_img_boundary, show_pred_gt, tile_image)
+                        show_img_boundary, show_pred_gt)
 
 from .evaluation import *  # NOQA
 
 __all__ = [
     'points2boundary', 'seg2boundary', 'extract_boundary', 'overlay_mask_img',
     'show_feature', 'show_img_boundary', 'show_pred_gt',
-    'imshow_pred_boundary', 'imshow_text_char_boundary', 'tile_image',
-    'imshow_text_label', 'imshow_edge_node', 'det_recog_show_result'
+    'imshow_pred_boundary', 'imshow_text_char_boundary', 'imshow_text_label',
+    'imshow_edge_node', 'det_recog_show_result'
 ]
 __all__ += evaluation.__all__

--- a/mmocr/core/__init__.py
+++ b/mmocr/core/__init__.py
@@ -1,3 +1,16 @@
-from .evaluation import *  # noqa: F401, F403
-from .mask import *  # noqa: F401, F403
-from .visualize import *  # noqa: F401, F403
+from . import evaluation
+from .mask import extract_boundary, points2boundary, seg2boundary
+from .visualize import (det_recog_show_result, imshow_edge_node,
+                        imshow_pred_boundary, imshow_text_char_boundary,
+                        imshow_text_label, overlay_mask_img, show_feature,
+                        show_img_boundary, show_pred_gt, tile_image)
+
+from .evaluation import *  # NOQA
+
+__all__ = [
+    'points2boundary', 'seg2boundary', 'extract_boundary', 'overlay_mask_img',
+    'show_feature', 'show_img_boundary', 'show_pred_gt',
+    'imshow_pred_boundary', 'imshow_text_char_boundary', 'tile_image',
+    'imshow_text_label', 'imshow_edge_node', 'det_recog_show_result'
+]
+__all__ += evaluation.__all__

--- a/mmocr/datasets/__init__.py
+++ b/mmocr/datasets/__init__.py
@@ -1,4 +1,5 @@
 from mmdet.datasets.builder import DATASETS, build_dataloader, build_dataset
+from . import utils
 from .base_dataset import BaseDataset
 from .icdar_dataset import IcdarDataset
 from .kie_dataset import KIEDataset
@@ -6,10 +7,13 @@ from .ocr_dataset import OCRDataset
 from .ocr_seg_dataset import OCRSegDataset
 from .pipelines import CustomFormatBundle, DBNetTargets
 from .text_det_dataset import TextDetDataset
-from .utils import *  # noqa: F401,F403
+
+from .utils import *  # NOQA
 
 __all__ = [
     'DATASETS', 'IcdarDataset', 'build_dataloader', 'build_dataset',
     'BaseDataset', 'OCRDataset', 'TextDetDataset', 'CustomFormatBundle',
     'DBNetTargets', 'OCRSegDataset', 'KIEDataset'
 ]
+
+__all__ += utils.__all__

--- a/mmocr/models/__init__.py
+++ b/mmocr/models/__init__.py
@@ -1,12 +1,14 @@
 from mmdet.models.builder import (BACKBONES, DETECTORS, HEADS, LOSSES, NECKS,
                                   build_backbone, build_detector, build_loss)
+from . import common, kie, textdet, textrecog
 from .builder import (CONVERTORS, DECODERS, ENCODERS, PREPROCESSOR,
                       build_convertor, build_decoder, build_encoder,
                       build_preprocessor)
-from .common import *  # noqa: F401,F403
-from .kie import *  # noqa: F401,F403
-from .textdet import *  # noqa: F401,F403
-from .textrecog import *  # noqa: F401,F403
+
+from .common import *  # NOQA
+from .kie import *  # NOQA
+from .textdet import *  # NOQA
+from .textrecog import *  # NOQA
 
 __all__ = [
     'BACKBONES', 'DETECTORS', 'HEADS', 'LOSSES', 'NECKS', 'build_backbone',
@@ -14,3 +16,4 @@ __all__ = [
     'PREPROCESSOR', 'build_convertor', 'build_encoder', 'build_decoder',
     'build_preprocessor'
 ]
+__all__ += common.__all__ + kie.__all__ + textdet.__all__ + textrecog.__all__

--- a/mmocr/models/common/__init__.py
+++ b/mmocr/models/common/__init__.py
@@ -1,2 +1,6 @@
-from .backbones import *  # noqa:  F401,F403
-from .losses import *  # noqa:  F401,F403
+from . import backbones, losses
+
+from .backbones import *  # NOQA
+from .losses import *  # NOQA
+
+__all__ = backbones.__all__ + losses.__all__

--- a/mmocr/models/kie/__init__.py
+++ b/mmocr/models/kie/__init__.py
@@ -1,3 +1,7 @@
-from .extractors import *  # noqa: F401,F403
-from .heads import *  # noqa: F401,F403
-from .losses import *  # noqa: F401,F403
+from . import extractors, heads, losses
+
+from .extractors import *  # NOQA
+from .heads import *  # NOQA
+from .losses import *  # NOQA
+
+__all__ = extractors.__all__ + heads.__all__ + losses.__all__

--- a/mmocr/models/textdet/__init__.py
+++ b/mmocr/models/textdet/__init__.py
@@ -1,5 +1,11 @@
-from .dense_heads import *  # noqa: F401,F403
-from .detectors import *  # noqa: F401,F403
-from .losses import *  # noqa: F401,F403
-from .necks import *  # noqa: F401,F403
-from .postprocess import *  # noqa: F401,F403
+from . import dense_heads, detectors, losses, necks, postprocess
+
+from .dense_heads import *  # NOQA
+from .detectors import *  # NOQA
+from .losses import *  # NOQA
+from .necks import *  # NOQA
+from .postprocess import *  # NOQA
+
+__all__ = (
+    dense_heads.__all__ + detectors.__all__ + losses.__all__ + necks.__all__ +
+    postprocess.__all__)

--- a/mmocr/models/textrecog/__init__.py
+++ b/mmocr/models/textrecog/__init__.py
@@ -1,9 +1,17 @@
-from .backbones import *  # noqa: F401,F403
-from .convertors import *  # noqa: F401,F403
-from .decoders import *  # noqa: F401,F403
-from .encoders import *  # noqa: F401,F403
-from .heads import *  # noqa: F401,F403
-from .losses import *  # noqa: F401,F403
-from .necks import *  # noqa: F401,F403
-from .preprocessor import *  # noqa: F401,F403
-from .recognizer import *  # noqa: F401,F403
+from . import (backbones, convertors, decoders, encoders, heads, losses, necks,
+               preprocessor, recognizer)
+
+from .backbones import *  # NOQA
+from .convertors import *  # NOQA
+from .decoders import *  # NOQA
+from .encoders import *  # NOQA
+from .heads import *  # NOQA
+from .losses import *  # NOQA
+from .necks import *  # NOQA
+from .preprocessor import *  # NOQA
+from .recognizer import *  # NOQA
+
+__all__ = (
+    backbones.__all__ + convertors.__all__ + decoders.__all__ +
+    encoders.__all__ + heads.__all__ + losses.__all__ + necks.__all__ +
+    preprocessor.__all__ + recognizer.__all__)


### PR DESCRIPTION
Previously, functions/objects imported by `from .xxx import *` are not listed in `__all__`. The current writing fixes that.