### PR TITLE
Fix installing requirements with pip and mim

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
+include requirements/*.txt
 include mmocr/model_zoo.yml
 recursive-include mmocr/configs *.py *.yml
 recursive-include mmocr/tools *.sh *.py

--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -4,6 +4,8 @@ lmdb
 matplotlib
 numba>=0.45.1
 numpy
+Polygon3
+pyclipper
 rapidfuzz
 scikit-image
 six


### PR DESCRIPTION
It seems that the packages in requirements/build.txt will not be installed when using pip and mim.