### PR TITLE
Fix key-value conflict of upsamle_layers between mmseg and mmocr.

### DIFF
--- a/mmocr/models/common/backbones/unet.py
+++ b/mmocr/models/common/backbones/unet.py
@@ -1,9 +1,9 @@
 import torch
 import torch.nn as nn
 import torch.utils.checkpoint as cp
+from mmcv.cnn import UPSAMPLE_LAYERS as MMCV_UPSAMPLE_LAYERS
 from mmcv.cnn import (ConvModule, build_activation_layer, build_norm_layer,
                       build_upsample_layer, constant_init, kaiming_init)
-from mmcv.cnn import UPSAMPLE_LAYERS as MMCV_UPSAMPLE_LAYERS
 from mmcv.runner import load_checkpoint
 from mmcv.utils import Registry
 from mmcv.utils.parrots_wrapper import _BatchNorm

--- a/mmocr/models/common/backbones/unet.py
+++ b/mmocr/models/common/backbones/unet.py
@@ -1,14 +1,17 @@
 import torch
 import torch.nn as nn
 import torch.utils.checkpoint as cp
-from mmcv.cnn import (UPSAMPLE_LAYERS, ConvModule, build_activation_layer,
-                      build_norm_layer, build_upsample_layer, constant_init,
-                      kaiming_init)
+from mmcv.cnn import (ConvModule, build_activation_layer, build_norm_layer,
+                      build_upsample_layer, constant_init, kaiming_init)
+from mmcv.cnn import UPSAMPLE_LAYERS as MMCV_UPSAMPLE_LAYERS
 from mmcv.runner import load_checkpoint
+from mmcv.utils import Registry
 from mmcv.utils.parrots_wrapper import _BatchNorm
 
 from mmdet.models.builder import BACKBONES
 from mmocr.utils import get_root_logger
+
+UPSAMPLE_LAYERS = Registry('upsample_layers', parent=MMCV_UPSAMPLE_LAYERS)
 
 
 class UpConvBlock(nn.Module):


### PR DESCRIPTION
To solve key-value conflict of upsample layers in unet between mmseg and mmocr, I add namespace when registering upsample layers.