### PR TITLE
Ignore img processing for KIE without visual

### DIFF
--- a/configs/kie/sdmgr/sdmgr_novisual_60e_wildreceipt.py
+++ b/configs/kie/sdmgr/sdmgr_novisual_60e_wildreceipt.py
@@ -4,6 +4,8 @@ max_scale, min_scale = 1024, 512
 
 train_pipeline = [
     dict(type='LoadAnnotations'),
+    dict(
+        type='ResizeNoImg', img_scale=(max_scale, min_scale), keep_ratio=True),
     dict(type='KIEFormatBundle'),
     dict(
         type='Collect',
@@ -12,6 +14,8 @@ train_pipeline = [
 ]
 test_pipeline = [
     dict(type='LoadAnnotations'),
+    dict(
+        type='ResizeNoImg', img_scale=(max_scale, min_scale), keep_ratio=True),
     dict(type='KIEFormatBundle'),
     dict(
         type='Collect',
@@ -47,7 +51,7 @@ test = dict(
     test_mode=True)
 
 data = dict(
-    samples_per_gpu=4, workers_per_gpu=1, train=train, val=test, test=test)
+    samples_per_gpu=4, workers_per_gpu=0, train=train, val=test, test=test)
 
 evaluation = dict(
     interval=1,

--- a/configs/kie/sdmgr/sdmgr_novisual_60e_wildreceipt.py
+++ b/configs/kie/sdmgr/sdmgr_novisual_60e_wildreceipt.py
@@ -51,7 +51,7 @@ test = dict(
     test_mode=True)
 
 data = dict(
-    samples_per_gpu=4, workers_per_gpu=0, train=train, val=test, test=test)
+    samples_per_gpu=4, workers_per_gpu=1, train=train, val=test, test=test)
 
 evaluation = dict(
     interval=1,

--- a/configs/kie/sdmgr/sdmgr_novisual_60e_wildreceipt.py
+++ b/configs/kie/sdmgr/sdmgr_novisual_60e_wildreceipt.py
@@ -3,26 +3,20 @@ img_norm_cfg = dict(
 max_scale, min_scale = 1024, 512
 
 train_pipeline = [
-    dict(type='LoadImageFromFile'),
     dict(type='LoadAnnotations'),
-    dict(type='Resize', img_scale=(max_scale, min_scale), keep_ratio=True),
-    dict(type='RandomFlip', flip_ratio=0.),
-    dict(type='Normalize', **img_norm_cfg),
-    dict(type='Pad', size_divisor=32),
     dict(type='KIEFormatBundle'),
     dict(
         type='Collect',
-        keys=['img', 'relations', 'texts', 'gt_bboxes', 'gt_labels'])
+        keys=['img', 'relations', 'texts', 'gt_bboxes', 'gt_labels'],
+        meta_keys=())
 ]
 test_pipeline = [
-    dict(type='LoadImageFromFile'),
     dict(type='LoadAnnotations'),
-    dict(type='Resize', img_scale=(max_scale, min_scale), keep_ratio=True),
-    dict(type='RandomFlip', flip_ratio=0.),
-    dict(type='Normalize', **img_norm_cfg),
-    dict(type='Pad', size_divisor=32),
     dict(type='KIEFormatBundle'),
-    dict(type='Collect', keys=['img', 'relations', 'texts', 'gt_bboxes'])
+    dict(
+        type='Collect',
+        keys=['img', 'relations', 'texts', 'gt_bboxes'],
+        meta_keys=())
 ]
 
 dataset_type = 'KIEDataset'
@@ -53,7 +47,7 @@ test = dict(
     test_mode=True)
 
 data = dict(
-    samples_per_gpu=4, workers_per_gpu=0, train=train, val=test, test=test)
+    samples_per_gpu=4, workers_per_gpu=1, train=train, val=test, test=test)
 
 evaluation = dict(
     interval=1,

--- a/configs/kie/sdmgr/sdmgr_unet16_60e_wildreceipt.py
+++ b/configs/kie/sdmgr/sdmgr_unet16_60e_wildreceipt.py
@@ -53,7 +53,7 @@ test = dict(
     test_mode=True)
 
 data = dict(
-    samples_per_gpu=4, workers_per_gpu=0, train=train, val=test, test=test)
+    samples_per_gpu=4, workers_per_gpu=4, train=train, val=test, test=test)
 
 evaluation = dict(
     interval=1,

--- a/mmocr/datasets/kie_dataset.py
+++ b/mmocr/datasets/kie_dataset.py
@@ -58,6 +58,7 @@ class KIEDataset(BaseDataset):
     def pre_pipeline(self, results):
         results['img_prefix'] = self.img_prefix
         results['bbox_fields'] = []
+        results['img'] = np.zeros((1, 1, 1), dtype=np.uint8)
 
     def _parse_anno_info(self, annotations):
         """Parse annotations of boxes, texts and labels for one image.

--- a/mmocr/datasets/pipelines/__init__.py
+++ b/mmocr/datasets/pipelines/__init__.py
@@ -1,7 +1,7 @@
 from .box_utils import sort_vertex, sort_vertex8
 from .custom_format_bundle import CustomFormatBundle
 from .dbnet_transforms import EastRandomCrop, ImgAug
-from .kie_transforms import KIEFormatBundle
+from .kie_transforms import KIEFormatBundle, ResizeNoImg
 from .loading import LoadImageFromNdarray, LoadTextAnnotations
 from .ner_transforms import NerTransform, ToTensorNER
 from .ocr_seg_targets import OCRSegTargets
@@ -25,5 +25,6 @@ __all__ = [
     'ImgAug', 'EastRandomCrop', 'RandomRotateImageBox', 'OpencvToPil',
     'PilToOpencv', 'KIEFormatBundle', 'SquareResizePad', 'TextSnakeTargets',
     'sort_vertex', 'LoadImageFromNdarray', 'sort_vertex8', 'FCENetTargets',
-    'RandomScaling', 'RandomCropFlip', 'NerTransform', 'ToTensorNER'
+    'RandomScaling', 'RandomCropFlip', 'NerTransform', 'ToTensorNER',
+    'ResizeNoImg'
 ]


### PR DESCRIPTION
5x speedup

Before:

![image](https://user-images.githubusercontent.com/9464825/120658057-afa7c880-c4b7-11eb-996d-4bb665910ef6.png)


After:

![image](https://user-images.githubusercontent.com/9464825/120657801-66577900-c4b7-11eb-9d9d-62d01dec41f5.png)

Fix https://github.com/open-mmlab/mmocr/issues/164
Fix https://github.com/open-mmlab/mmocr/issues/238
