### PR TITLE
Update MMOCR_Tutorial.ipynb

### DIFF
--- a/demo/MMOCR_Tutorial.ipynb
+++ b/demo/MMOCR_Tutorial.ipynb
@@ -154,6 +154,7 @@
         "\n",
         "# Install mmocr\n",
         "!git clone https://github.com/open-mmlab/mmocr.git\n",
+        "%cd mmocr\n",
         "!pip install -r requirements.txt\n",
         "!pip install -v -e .\n",
         "\n",


### PR DESCRIPTION
add change directory to `mmocr` after git clone: `%cd mmocr`
"!pip install -r requirements.txt\n", was failing in colab as after git clone one needs to change dir to mmocr.