### PR TITLE
use unifor_concat_datase instead of concat_dataset

### DIFF
--- a/configs/_base_/recog_datasets/seg_toy_dataset.py
+++ b/configs/_base_/recog_datasets/seg_toy_dataset.py
@@ -87,10 +87,6 @@ test = dict(
     test_mode=True)
 
 data = dict(
-    samples_per_gpu=8,
-    workers_per_gpu=1,
-    train=dict(type='ConcatDataset', datasets=[train]),
-    val=dict(type='ConcatDataset', datasets=[test]),
-    test=dict(type='ConcatDataset', datasets=[test]))
+    samples_per_gpu=8, workers_per_gpu=1, train=train, val=test, test=test)
 
 evaluation = dict(interval=1, metric='acc')

--- a/configs/textrecog/crnn/crnn_academic_dataset.py
+++ b/configs/textrecog/crnn/crnn_academic_dataset.py
@@ -91,7 +91,7 @@ train1 = dict(
             keys=['filename', 'text'],
             keys_idx=[0, 1],
             separator=' ')),
-    pipeline=train_pipeline,
+    pipeline=None,
     test_mode=False)
 
 test_prefix = 'data/mixture/'
@@ -122,7 +122,7 @@ test1 = dict(
             keys=['filename', 'text'],
             keys_idx=[0, 1],
             separator=' ')),
-    pipeline=test_pipeline,
+    pipeline=None,
     test_mode=True)
 
 test2 = {key: value for key, value in test1.items()}
@@ -150,13 +150,18 @@ data = dict(
     workers_per_gpu=4,
     val_dataloader=dict(samples_per_gpu=1),
     test_dataloader=dict(samples_per_gpu=1),
-    train=dict(type='ConcatDataset', datasets=[train1]),
+    train=dict(
+        type='UniformConcatDataset',
+        datasets=[train1],
+        pipeline=train_pipeline),
     val=dict(
-        type='ConcatDataset',
-        datasets=[test1, test2, test3, test4, test5, test6]),
+        type='UniformConcatDataset',
+        datasets=[test1, test2, test3, test4, test5, test6],
+        pipeline=test_pipeline),
     test=dict(
-        type='ConcatDataset',
-        datasets=[test1, test2, test3, test4, test5, test6]))
+        type='UniformConcatDataset',
+        datasets=[test1, test2, test3, test4, test5, test6],
+        pipeline=test_pipeline))
 
 evaluation = dict(interval=1, metric='acc')
 

--- a/configs/textrecog/nrtr/nrtr_r31_1by16_1by8_academic.py
+++ b/configs/textrecog/nrtr/nrtr_r31_1by16_1by8_academic.py
@@ -92,7 +92,7 @@ train1 = dict(
             keys=['filename', 'text'],
             keys_idx=[0, 1],
             separator=' ')),
-    pipeline=train_pipeline,
+    pipeline=None,
     test_mode=False)
 
 train2 = {key: value for key, value in train1.items()}
@@ -126,7 +126,7 @@ test1 = dict(
             keys=['filename', 'text'],
             keys_idx=[0, 1],
             separator=' ')),
-    pipeline=test_pipeline,
+    pipeline=None,
     test_mode=True)
 
 test2 = {key: value for key, value in test1.items()}
@@ -154,12 +154,17 @@ data = dict(
     workers_per_gpu=4,
     val_dataloader=dict(samples_per_gpu=1),
     test_dataloader=dict(samples_per_gpu=1),
-    train=dict(type='ConcatDataset', datasets=[train1, train2]),
+    train=dict(
+        type='UniformConcatDataset',
+        datasets=[train1, train2],
+        pipeline=train_pipeline),
     val=dict(
-        type='ConcatDataset',
-        datasets=[test1, test2, test3, test4, test5, test6]),
+        type='UniformConcatDataset',
+        datasets=[test1, test2, test3, test4, test5, test6],
+        pipeline=test_pipeline),
     test=dict(
-        type='ConcatDataset',
-        datasets=[test1, test2, test3, test4, test5, test6]))
+        type='UniformConcatDataset',
+        datasets=[test1, test2, test3, test4, test5, test6],
+        pipeline=test_pipeline))
 
 evaluation = dict(interval=1, metric='acc')

--- a/configs/textrecog/nrtr/nrtr_r31_1by8_1by4_academic.py
+++ b/configs/textrecog/nrtr/nrtr_r31_1by8_1by4_academic.py
@@ -92,7 +92,7 @@ train1 = dict(
             keys=['filename', 'text'],
             keys_idx=[0, 1],
             separator=' ')),
-    pipeline=train_pipeline,
+    pipeline=None,
     test_mode=False)
 
 train2 = {key: value for key, value in train1.items()}
@@ -126,7 +126,7 @@ test1 = dict(
             keys=['filename', 'text'],
             keys_idx=[0, 1],
             separator=' ')),
-    pipeline=test_pipeline,
+    pipeline=None,
     test_mode=True)
 
 test2 = {key: value for key, value in test1.items()}
@@ -154,12 +154,17 @@ data = dict(
     workers_per_gpu=4,
     val_dataloader=dict(samples_per_gpu=1),
     test_dataloader=dict(samples_per_gpu=1),
-    train=dict(type='ConcatDataset', datasets=[train1, train2]),
+    train=dict(
+        type='UniformConcatDataset',
+        datasets=[train1, train2],
+        pipeline=train_pipeline),
     val=dict(
-        type='ConcatDataset',
-        datasets=[test1, test2, test3, test4, test5, test6]),
+        type='UniformConcatDataset',
+        datasets=[test1, test2, test3, test4, test5, test6],
+        pipeline=test_pipeline),
     test=dict(
-        type='ConcatDataset',
-        datasets=[test1, test2, test3, test4, test5, test6]))
+        type='UniformConcatDataset',
+        datasets=[test1, test2, test3, test4, test5, test6],
+        pipeline=test_pipeline))
 
 evaluation = dict(interval=1, metric='acc')

--- a/configs/textrecog/robust_scanner/robustscanner_r31_academic.py
+++ b/configs/textrecog/robust_scanner/robustscanner_r31_academic.py
@@ -87,7 +87,7 @@ train1 = dict(
             keys=['filename', 'text'],
             keys_idx=[0, 1],
             separator=' ')),
-    pipeline=train_pipeline,
+    pipeline=None,
     test_mode=False)
 
 train2 = {key: value for key, value in train1.items()}
@@ -118,7 +118,7 @@ train6 = dict(
             keys=['filename', 'text'],
             keys_idx=[0, 1],
             separator=' ')),
-    pipeline=train_pipeline,
+    pipeline=None,
     test_mode=False)
 
 train7 = {key: value for key, value in train6.items()}
@@ -156,7 +156,7 @@ test1 = dict(
             keys=['filename', 'text'],
             keys_idx=[0, 1],
             separator=' ')),
-    pipeline=test_pipeline,
+    pipeline=None,
     test_mode=True)
 
 test2 = {key: value for key, value in test1.items()}
@@ -185,15 +185,18 @@ data = dict(
     val_dataloader=dict(samples_per_gpu=1),
     test_dataloader=dict(samples_per_gpu=1),
     train=dict(
-        type='ConcatDataset',
+        type='UniformConcatDataset',
         datasets=[
             train1, train2, train3, train4, train5, train6, train7, train8
-        ]),
+        ],
+        pipeline=train_pipeline),
     val=dict(
-        type='ConcatDataset',
-        datasets=[test1, test2, test3, test4, test5, test6]),
+        type='UniformConcatDataset',
+        datasets=[test1, test2, test3, test4, test5, test6],
+        pipeline=test_pipeline),
     test=dict(
-        type='ConcatDataset',
-        datasets=[test1, test2, test3, test4, test5, test6]))
+        type='UniformConcatDataset',
+        datasets=[test1, test2, test3, test4, test5, test6],
+        pipeline=test_pipeline))
 
 evaluation = dict(interval=1, metric='acc')

--- a/configs/textrecog/sar/sar_r31_parallel_decoder_academic.py
+++ b/configs/textrecog/sar/sar_r31_parallel_decoder_academic.py
@@ -109,7 +109,7 @@ train1 = dict(
             keys=['filename', 'text'],
             keys_idx=[0, 1],
             separator=' ')),
-    pipeline=train_pipeline,
+    pipeline=None,
     test_mode=False)
 
 train2 = {key: value for key, value in train1.items()}
@@ -140,7 +140,7 @@ train6 = dict(
             keys=['filename', 'text'],
             keys_idx=[0, 1],
             separator=' ')),
-    pipeline=train_pipeline,
+    pipeline=None,
     test_mode=False)
 
 train7 = {key: value for key, value in train6.items()}
@@ -178,7 +178,7 @@ test1 = dict(
             keys=['filename', 'text'],
             keys_idx=[0, 1],
             separator=' ')),
-    pipeline=test_pipeline,
+    pipeline=None,
     test_mode=True)
 
 test2 = {key: value for key, value in test1.items()}
@@ -207,15 +207,18 @@ data = dict(
     val_dataloader=dict(samples_per_gpu=1),
     test_dataloader=dict(samples_per_gpu=1),
     train=dict(
-        type='ConcatDataset',
+        type='UniformConcatDataset',
         datasets=[
             train1, train2, train3, train4, train5, train6, train7, train8
-        ]),
+        ],
+        pipeline=train_pipeline),
     val=dict(
-        type='ConcatDataset',
-        datasets=[test1, test2, test3, test4, test5, test6]),
+        type='UniformConcatDataset',
+        datasets=[test1, test2, test3, test4, test5, test6],
+        pipeline=test_pipeline),
     test=dict(
-        type='ConcatDataset',
-        datasets=[test1, test2, test3, test4, test5, test6]))
+        type='UniformConcatDataset',
+        datasets=[test1, test2, test3, test4, test5, test6],
+        pipeline=test_pipeline))
 
 evaluation = dict(interval=1, metric='acc')

--- a/configs/textrecog/sar/sar_r31_parallel_decoder_chinese.py
+++ b/configs/textrecog/sar/sar_r31_parallel_decoder_chinese.py
@@ -94,7 +94,7 @@ train = dict(
             keys=['filename', 'text'],
             keys_idx=[0, 1],
             separator=' ')),
-    pipeline=train_pipeline,
+    pipeline=None,
     test_mode=False)
 
 test_prefix = 'data/chineseocr/'
@@ -113,7 +113,7 @@ test = dict(
             keys=['filename', 'text'],
             keys_idx=[0, 1],
             separator=' ')),
-    pipeline=test_pipeline,
+    pipeline=None,
     test_mode=False)
 
 data = dict(
@@ -121,8 +121,12 @@ data = dict(
     workers_per_gpu=2,
     val_dataloader=dict(samples_per_gpu=1),
     test_dataloader=dict(samples_per_gpu=1),
-    train=dict(type='ConcatDataset', datasets=[train]),
-    val=dict(type='ConcatDataset', datasets=[test]),
-    test=dict(type='ConcatDataset', datasets=[test]))
+    train=dict(
+        type='UniformConcatDataset', datasets=[train],
+        pipeline=train_pipeline),
+    val=dict(
+        type='UniformConcatDataset', datasets=[test], pipeline=test_pipeline),
+    test=dict(
+        type='UniformConcatDataset', datasets=[test], pipeline=test_pipeline))
 
 evaluation = dict(interval=1, metric='acc')

--- a/configs/textrecog/sar/sar_r31_sequential_decoder_academic.py
+++ b/configs/textrecog/sar/sar_r31_sequential_decoder_academic.py
@@ -109,7 +109,7 @@ train1 = dict(
             keys=['filename', 'text'],
             keys_idx=[0, 1],
             separator=' ')),
-    pipeline=train_pipeline,
+    pipeline=None,
     test_mode=False)
 
 train2 = {key: value for key, value in train1.items()}
@@ -140,7 +140,7 @@ train6 = dict(
             keys=['filename', 'text'],
             keys_idx=[0, 1],
             separator=' ')),
-    pipeline=train_pipeline,
+    pipeline=None,
     test_mode=False)
 
 train7 = {key: value for key, value in train6.items()}
@@ -178,7 +178,7 @@ test1 = dict(
             keys=['filename', 'text'],
             keys_idx=[0, 1],
             separator=' ')),
-    pipeline=test_pipeline,
+    pipeline=None,
     test_mode=True)
 
 test2 = {key: value for key, value in test1.items()}
@@ -207,15 +207,18 @@ data = dict(
     val_dataloader=dict(samples_per_gpu=1),
     test_dataloader=dict(samples_per_gpu=1),
     train=dict(
-        type='ConcatDataset',
+        type='UniformConcatDataset',
         datasets=[
             train1, train2, train3, train4, train5, train6, train7, train8
-        ]),
+        ],
+        pipeline=train_pipeline),
     val=dict(
-        type='ConcatDataset',
-        datasets=[test1, test2, test3, test4, test5, test6]),
+        type='UniformConcatDataset',
+        datasets=[test1, test2, test3, test4, test5, test6],
+        pipeline=test_pipeline),
     test=dict(
-        type='ConcatDataset',
-        datasets=[test1, test2, test3, test4, test5, test6]))
+        type='UniformConcatDataset',
+        datasets=[test1, test2, test3, test4, test5, test6],
+        pipeline=test_pipeline))
 
 evaluation = dict(interval=1, metric='acc')

--- a/configs/textrecog/seg/seg_r31_1by16_fpnocr_academic.py
+++ b/configs/textrecog/seg/seg_r31_1by16_fpnocr_academic.py
@@ -107,7 +107,7 @@ train = dict(
         repeat=1,
         parser=dict(
             type='LineJsonParser', keys=['file_name', 'annotations', 'text'])),
-    pipeline=train_pipeline,
+    pipeline=None,
     test_mode=False)
 
 dataset_type = 'OCRDataset'
@@ -135,7 +135,7 @@ test1 = dict(
             keys=['filename', 'text'],
             keys_idx=[0, 1],
             separator=' ')),
-    pipeline=test_pipeline,
+    pipeline=None,
     test_mode=True)
 
 test2 = {key: value for key, value in test1.items()}
@@ -153,8 +153,16 @@ test4['ann_file'] = test_ann_file4
 data = dict(
     samples_per_gpu=16,
     workers_per_gpu=2,
-    train=dict(type='ConcatDataset', datasets=[train]),
-    val=dict(type='ConcatDataset', datasets=[test1, test2, test3, test4]),
-    test=dict(type='ConcatDataset', datasets=[test1, test2, test3, test4]))
+    train=dict(
+        type='UniformConcatDataset', datasets=[train],
+        pipeline=train_pipeline),
+    val=dict(
+        type='UniformConcatDataset',
+        datasets=[test1, test2, test3, test4],
+        pipeline=test_pipeline),
+    test=dict(
+        type='UniformConcatDataset',
+        datasets=[test1, test2, test3, test4],
+        pipeline=test_pipeline))
 
 evaluation = dict(interval=1, metric='acc')

--- a/configs/textrecog/tps/crnn_tps_academic_dataset.py
+++ b/configs/textrecog/tps/crnn_tps_academic_dataset.py
@@ -84,7 +84,7 @@ dataset_type = 'OCRDataset'
 train_img_prefix = 'data/mixture/Syn90k/mnt/ramdisk/max/90kDICT32px'
 train_ann_file = 'data/mixture/Syn90k/label.lmdb'
 
-train1 = dict(
+train = dict(
     type=dataset_type,
     img_prefix=train_img_prefix,
     ann_file=train_ann_file,
@@ -127,7 +127,7 @@ test1 = dict(
             keys=['filename', 'text'],
             keys_idx=[0, 1],
             separator=' ')),
-    pipeline=test_pipeline,
+    pipeline=None,
     test_mode=True)
 
 test2 = {key: value for key, value in test1.items()}
@@ -153,13 +153,15 @@ test6['ann_file'] = test_ann_file6
 data = dict(
     samples_per_gpu=64,
     workers_per_gpu=4,
-    train=dict(type='ConcatDataset', datasets=[train1]),
+    train=train,
     val=dict(
-        type='ConcatDataset',
-        datasets=[test1, test2, test3, test4, test5, test6]),
+        type='UniformConcatDataset',
+        datasets=[test1, test2, test3, test4, test5, test6],
+        pipeline=test_pipeline),
     test=dict(
-        type='ConcatDataset',
-        datasets=[test1, test2, test3, test4, test5, test6]))
+        type='UniformConcatDataset',
+        datasets=[test1, test2, test3, test4, test5, test6],
+        pipeline=test_pipeline))
 
 evaluation = dict(interval=1, metric='acc')
 

--- a/mmocr/datasets/uniform_concat_dataset.py
+++ b/mmocr/datasets/uniform_concat_dataset.py
@@ -22,6 +22,7 @@ class UniformConcatDataset(ConcatDataset):
         if pipeline is not None:
             assert from_cfg, 'datasets should be config dicts'
             for dataset in datasets:
-                dataset['pipeline'] = copy.deepcopy(pipeline)
+                if dataset['pipeline'] is None:
+                    dataset['pipeline'] = copy.deepcopy(pipeline)
         datasets = [build_dataset(c, kwargs) for c in datasets]
         super().__init__(datasets, separate_eval)

--- a/tests/test_dataset/test_uniform_concat_dataset.py
+++ b/tests/test_dataset/test_uniform_concat_dataset.py
@@ -1,0 +1,34 @@
+from mmocr.datasets import UniformConcatDataset
+from mmocr.utils import list_from_file
+
+
+def test_dataset_warpper():
+    pipeline1 = [dict(type='LoadImageFromFile')]
+    pipeline2 = [dict(type='LoadImageFromFile'), dict(type='ColorJitter')]
+
+    img_prefix = 'tests/data/ocr_toy_dataset/imgs'
+    ann_file = 'tests/data/ocr_toy_dataset/label.txt'
+    train1 = dict(
+        type='OCRDataset',
+        img_prefix=img_prefix,
+        ann_file=ann_file,
+        loader=dict(
+            type='HardDiskLoader',
+            repeat=1,
+            parser=dict(
+                type='LineStrParser',
+                keys=['filename', 'text'],
+                keys_idx=[0, 1],
+                separator=' ')),
+        pipeline=None,
+        test_mode=False)
+
+    train2 = {key: value for key, value in train1.items()}
+    train2['pipeline'] = pipeline2
+
+    uniform_concat_dataset = UniformConcatDataset(
+        datasets=[train1, train2], pipeline=pipeline1)
+
+    assert len(uniform_concat_dataset) == 2 * len(list_from_file(ann_file))
+    assert len(uniform_concat_dataset.datasets[0].pipeline.transforms) != len(
+        uniform_concat_dataset.datasets[1].pipeline.transforms)


### PR DESCRIPTION
Use `uniform_concat_dataset` such that `cfg.data.val` and `cfg.data.test` have attribute `pipeline`.