### PR TITLE
Added support for ConcatDataset with two workflows

### DIFF
--- a/tools/train.py
+++ b/tools/train.py
@@ -186,7 +186,16 @@ def main():
     datasets = [build_dataset(cfg.data.train)]
     if len(cfg.workflow) == 2:
         val_dataset = copy.deepcopy(cfg.data.val)
-        val_dataset.pipeline = cfg.data.train.pipeline
+        if cfg.data.train['type'] == 'ConcatDataset':
+            train_pipeline = cfg.data.train['datasets'][0].pipeline
+        else:
+            train_pipeline = cfg.data.train.pipeline
+
+        if val_dataset['type'] == 'ConcatDataset':
+            for dataset in val_dataset['datasets']:
+                dataset.pipeline = train_pipeline
+        else:
+            val_dataset.pipeline = train_pipeline
         datasets.append(build_dataset(val_dataset))
     if cfg.checkpoint_config is not None:
         # save mmdet version, config file content and class names in


### PR DESCRIPTION
This PR added support for `ConcatDataset` with two workflows. In particular, if one wants to use `workflow = [('train', 1), ('val', 1)]` but in the configuration file there is a `ConcatDataset`, the actual `tools/train.py` is not able to handle it. In this case, as a hotfix, I propose to set the pipeline for each dataset in `datasets`. 

Note: I have seen the new `UniformConcatDataset`'s implementation and in the future I will use this new MMOCR component, but for the people that still continue to use `ConcatDataset`, I suppose this PR could help.