### PR TITLE
[Docs] fix dead links, remove invalid TOC in CN docs

### DIFF
--- a/docs/datasets.md
+++ b/docs/datasets.md
@@ -9,7 +9,6 @@ This page lists the datasets which are commonly used in text detection, text rec
   - [Text Recognition](#text-recognition)
   - [Key Information Extraction](#key-information-extraction)
   - [Named Entity Recognition](#named-entity-recognition)
-    - [CLUENER2020](#cluener2020)
 
 <!-- /TOC -->
 
@@ -382,8 +381,6 @@ The structure of the key information extraction dataset directory is organized a
 
 ## Named Entity Recognition
 
-### CLUENER2020
-
 The structure of the named entity recognition dataset directory is organized as follows.
 
 ```text
@@ -398,4 +395,4 @@ The structure of the named entity recognition dataset directory is organized as 
 ```
 - Download [cluener_public.zip](https://storage.googleapis.com/cluebenchmark/tasks/cluener_public.zip)
 
-- Download [vocab.txt](https://download.openmmlab.com/mmocr/data/cluener2020/vocab.txt) and move `vocab.txt` to `cluener2020`
+- Download [vocab.txt](https://download.openmmlab.com/mmocr/data/cluener_public/vocab.txt) and move `vocab.txt` to `cluener2020`

--- a/docs_zh_CN/datasets.md
+++ b/docs_zh_CN/datasets.md
@@ -2,18 +2,6 @@
 
 本页列出了在文字检测、文字识别、关键信息提取、命名实体识别四个文本类任务中常用的数据集以及下载链接。
 
-<!-- TOC -->
-
-- [数据集](#数据集)
-  - [文字检测](#文字检测)
-  - [文字识别](#文字识别)
-  - [关键信息提取](#关键信息提取)
-  - [命名实体识别（专名识别）](#命名实体识别（专名识别）)
-    - [CLUENER2020](#cluener2020)
-
-<!-- /TOC -->
-
-
 ## 文字检测
 
 文字检测任务的数据集应按如下目录配置：
@@ -385,8 +373,6 @@ python tools/data/utils/txt2lmdb.py -i data/mixture/Syn90k/label.txt -o data/mix
 
 ## 命名实体识别（专名识别）
 
-### CLUENER2020
-
 命名实体识别任务的数据集，文件目录应按如下配置：
 
 ```text
@@ -402,4 +388,4 @@ python tools/data/utils/txt2lmdb.py -i data/mixture/Syn90k/label.txt -o data/mix
 
 - 下载 [cluener_public.zip](https://storage.googleapis.com/cluebenchmark/tasks/cluener_public.zip)
 
-- 下载 [vocab.txt](https://download.openmmlab.com/mmocr/data/cluener2020/vocab.txt) 然后将 `vocab.txt` 移动到 `cluener2020` 文件夹下
+- 下载 [vocab.txt](https://download.openmmlab.com/mmocr/data/cluener_public/vocab.txt) 然后将 `vocab.txt` 移动到 `cluener2020` 文件夹下


### PR DESCRIPTION
Removed TOC because Readthedocs can't link Chinese TOC to its corresponding content