### PR TITLE
Fix #112: Remove the need of drop_orientation_info in data preprocessing steps

### DIFF
--- a/configs/_base_/det_dataset/toy_dataset.py
+++ b/configs/_base_/det_dataset/toy_dataset.py
@@ -5,7 +5,7 @@ train_cfg = None
 test_cfg = None
 
 train_pipeline = [
-    dict(type='LoadOCRImageFromFile'),
+    dict(type='LoadImageFromFile', color_type='color_ignore_orientation'),
     dict(
         type='LoadTextAnnotations',
         with_bbox=True,
@@ -36,7 +36,7 @@ train_pipeline = [
     dict(type='Collect', keys=['img', 'gt_kernels', 'gt_mask'])
 ]
 test_pipeline = [
-    dict(type='LoadOCRImageFromFile'),
+    dict(type='LoadImageFromFile', color_type='color_ignore_orientation'),
     dict(
         type='MultiScaleFlipAug',
         img_scale=(3000, 640),

--- a/configs/_base_/det_dataset/toy_dataset.py
+++ b/configs/_base_/det_dataset/toy_dataset.py
@@ -5,7 +5,7 @@ train_cfg = None
 test_cfg = None
 
 train_pipeline = [
-    dict(type='LoadImageFromFile'),
+    dict(type='LoadOCRImageFromFile'),
     dict(
         type='LoadTextAnnotations',
         with_bbox=True,
@@ -36,7 +36,7 @@ train_pipeline = [
     dict(type='Collect', keys=['img', 'gt_kernels', 'gt_mask'])
 ]
 test_pipeline = [
-    dict(type='LoadImageFromFile'),
+    dict(type='LoadOCRImageFromFile'),
     dict(
         type='MultiScaleFlipAug',
         img_scale=(3000, 640),

--- a/configs/_base_/recog_datasets/toy_dataset.py
+++ b/configs/_base_/recog_datasets/toy_dataset.py
@@ -1,6 +1,6 @@
 img_norm_cfg = dict(mean=[0.5, 0.5, 0.5], std=[0.5, 0.5, 0.5])
 train_pipeline = [
-    dict(type='LoadOCRImageFromFile'),
+    dict(type='LoadImageFromFile', color_type='color_ignore_orientation'),
     dict(
         type='ResizeOCR',
         height=32,
@@ -17,7 +17,7 @@ train_pipeline = [
         ]),
 ]
 test_pipeline = [
-    dict(type='LoadOCRImageFromFile'),
+    dict(type='LoadImageFromFile', color_type='color_ignore_orientation'),
     dict(
         type='MultiRotateAugOCR',
         rotate_degrees=[0, 90, 270],

--- a/configs/_base_/recog_datasets/toy_dataset.py
+++ b/configs/_base_/recog_datasets/toy_dataset.py
@@ -1,6 +1,6 @@
 img_norm_cfg = dict(mean=[0.5, 0.5, 0.5], std=[0.5, 0.5, 0.5])
 train_pipeline = [
-    dict(type='LoadImageFromFile'),
+    dict(type='LoadOCRImageFromFile'),
     dict(
         type='ResizeOCR',
         height=32,
@@ -17,7 +17,7 @@ train_pipeline = [
         ]),
 ]
 test_pipeline = [
-    dict(type='LoadImageFromFile'),
+    dict(type='LoadOCRImageFromFile'),
     dict(
         type='MultiRotateAugOCR',
         rotate_degrees=[0, 90, 270],

--- a/configs/textdet/dbnet/dbnet_r18_fpnc_1200e_icdar2015.py
+++ b/configs/textdet/dbnet/dbnet_r18_fpnc_1200e_icdar2015.py
@@ -31,7 +31,7 @@ img_norm_cfg = dict(
 # img_norm_cfg = dict(mean=[0, 0, 0], std=[1, 1, 1], to_rgb=True)
 
 train_pipeline = [
-    dict(type='LoadOCRImageFromFile'),
+    dict(type='LoadImageFromFile', color_type='color_ignore_orientation'),
     dict(
         type='LoadTextAnnotations',
         with_bbox=True,
@@ -58,7 +58,7 @@ train_pipeline = [
         keys=['img', 'gt_shrink', 'gt_shrink_mask', 'gt_thr', 'gt_thr_mask'])
 ]
 test_pipeline = [
-    dict(type='LoadOCRImageFromFile'),
+    dict(type='LoadImageFromFile', color_type='color_ignore_orientation'),
     dict(
         type='MultiScaleFlipAug',
         img_scale=(1333, 736),

--- a/configs/textdet/dbnet/dbnet_r18_fpnc_1200e_icdar2015.py
+++ b/configs/textdet/dbnet/dbnet_r18_fpnc_1200e_icdar2015.py
@@ -31,7 +31,7 @@ img_norm_cfg = dict(
 # img_norm_cfg = dict(mean=[0, 0, 0], std=[1, 1, 1], to_rgb=True)
 
 train_pipeline = [
-    dict(type='LoadImageFromFile', color_type='color_ignore_orientation'),
+    dict(type='LoadOCRImageFromFile'),
     dict(
         type='LoadTextAnnotations',
         with_bbox=True,
@@ -58,7 +58,7 @@ train_pipeline = [
         keys=['img', 'gt_shrink', 'gt_shrink_mask', 'gt_thr', 'gt_thr_mask'])
 ]
 test_pipeline = [
-    dict(type='LoadImageFromFile', color_type='color_ignore_orientation'),
+    dict(type='LoadOCRImageFromFile'),
     dict(
         type='MultiScaleFlipAug',
         img_scale=(1333, 736),

--- a/configs/textdet/dbnet/dbnet_r18_fpnc_1200e_icdar2015.py
+++ b/configs/textdet/dbnet/dbnet_r18_fpnc_1200e_icdar2015.py
@@ -31,7 +31,7 @@ img_norm_cfg = dict(
 # img_norm_cfg = dict(mean=[0, 0, 0], std=[1, 1, 1], to_rgb=True)
 
 train_pipeline = [
-    dict(type='LoadImageFromFile'),
+    dict(type='LoadImageFromFile', color_type='color_ignore_orientation'),
     dict(
         type='LoadTextAnnotations',
         with_bbox=True,
@@ -58,7 +58,7 @@ train_pipeline = [
         keys=['img', 'gt_shrink', 'gt_shrink_mask', 'gt_thr', 'gt_thr_mask'])
 ]
 test_pipeline = [
-    dict(type='LoadImageFromFile'),
+    dict(type='LoadImageFromFile', color_type='color_ignore_orientation'),
     dict(
         type='MultiScaleFlipAug',
         img_scale=(1333, 736),

--- a/configs/textdet/dbnet/dbnet_r50dcnv2_fpnc_1200e_icdar2015.py
+++ b/configs/textdet/dbnet/dbnet_r50dcnv2_fpnc_1200e_icdar2015.py
@@ -40,7 +40,7 @@ img_norm_cfg = dict(
 # img_norm_cfg = dict(mean=[0, 0, 0], std=[1, 1, 1], to_rgb=True)
 
 train_pipeline = [
-    dict(type='LoadImageFromFile'),
+    dict(type='LoadImageFromFile', color_type='color_ignore_orientation'),
     dict(
         type='LoadTextAnnotations',
         with_bbox=True,
@@ -67,7 +67,7 @@ train_pipeline = [
         keys=['img', 'gt_shrink', 'gt_shrink_mask', 'gt_thr', 'gt_thr_mask'])
 ]
 test_pipeline = [
-    dict(type='LoadImageFromFile'),
+    dict(type='LoadImageFromFile', color_type='color_ignore_orientation'),
     dict(
         type='MultiScaleFlipAug',
         img_scale=(4068, 1024),

--- a/configs/textdet/dbnet/dbnet_r50dcnv2_fpnc_1200e_icdar2015.py
+++ b/configs/textdet/dbnet/dbnet_r50dcnv2_fpnc_1200e_icdar2015.py
@@ -40,7 +40,7 @@ img_norm_cfg = dict(
 # img_norm_cfg = dict(mean=[0, 0, 0], std=[1, 1, 1], to_rgb=True)
 
 train_pipeline = [
-    dict(type='LoadImageFromFile', color_type='color_ignore_orientation'),
+    dict(type='LoadOCRImageFromFile'),
     dict(
         type='LoadTextAnnotations',
         with_bbox=True,
@@ -67,7 +67,7 @@ train_pipeline = [
         keys=['img', 'gt_shrink', 'gt_shrink_mask', 'gt_thr', 'gt_thr_mask'])
 ]
 test_pipeline = [
-    dict(type='LoadImageFromFile', color_type='color_ignore_orientation'),
+    dict(type='LoadOCRImageFromFile'),
     dict(
         type='MultiScaleFlipAug',
         img_scale=(4068, 1024),

--- a/configs/textdet/dbnet/dbnet_r50dcnv2_fpnc_1200e_icdar2015.py
+++ b/configs/textdet/dbnet/dbnet_r50dcnv2_fpnc_1200e_icdar2015.py
@@ -40,7 +40,7 @@ img_norm_cfg = dict(
 # img_norm_cfg = dict(mean=[0, 0, 0], std=[1, 1, 1], to_rgb=True)
 
 train_pipeline = [
-    dict(type='LoadOCRImageFromFile'),
+    dict(type='LoadImageFromFile', color_type='color_ignore_orientation'),
     dict(
         type='LoadTextAnnotations',
         with_bbox=True,
@@ -67,7 +67,7 @@ train_pipeline = [
         keys=['img', 'gt_shrink', 'gt_shrink_mask', 'gt_thr', 'gt_thr_mask'])
 ]
 test_pipeline = [
-    dict(type='LoadOCRImageFromFile'),
+    dict(type='LoadImageFromFile', color_type='color_ignore_orientation'),
     dict(
         type='MultiScaleFlipAug',
         img_scale=(4068, 1024),

--- a/configs/textdet/drrg/drrg_r50_fpn_unet_1200e_ctw1500.py
+++ b/configs/textdet/drrg/drrg_r50_fpn_unet_1200e_ctw1500.py
@@ -33,7 +33,7 @@ img_norm_cfg = dict(
     mean=[123.675, 116.28, 103.53], std=[58.395, 57.12, 57.375], to_rgb=True)
 
 train_pipeline = [
-    dict(type='LoadImageFromFile'),
+    dict(type='LoadImageFromFile', color_type='color_ignore_orientation'),
     dict(
         type='LoadTextAnnotations',
         with_bbox=True,
@@ -75,7 +75,7 @@ train_pipeline = [
         ])
 ]
 test_pipeline = [
-    dict(type='LoadImageFromFile'),
+    dict(type='LoadImageFromFile', color_type='color_ignore_orientation'),
     dict(
         type='MultiScaleFlipAug',
         img_scale=(1024, 640),

--- a/configs/textdet/drrg/drrg_r50_fpn_unet_1200e_ctw1500.py
+++ b/configs/textdet/drrg/drrg_r50_fpn_unet_1200e_ctw1500.py
@@ -33,7 +33,7 @@ img_norm_cfg = dict(
     mean=[123.675, 116.28, 103.53], std=[58.395, 57.12, 57.375], to_rgb=True)
 
 train_pipeline = [
-    dict(type='LoadImageFromFile', color_type='color_ignore_orientation'),
+    dict(type='LoadOCRImageFromFile'),
     dict(
         type='LoadTextAnnotations',
         with_bbox=True,
@@ -75,7 +75,7 @@ train_pipeline = [
         ])
 ]
 test_pipeline = [
-    dict(type='LoadImageFromFile', color_type='color_ignore_orientation'),
+    dict(type='LoadOCRImageFromFile'),
     dict(
         type='MultiScaleFlipAug',
         img_scale=(1024, 640),

--- a/configs/textdet/drrg/drrg_r50_fpn_unet_1200e_ctw1500.py
+++ b/configs/textdet/drrg/drrg_r50_fpn_unet_1200e_ctw1500.py
@@ -33,7 +33,7 @@ img_norm_cfg = dict(
     mean=[123.675, 116.28, 103.53], std=[58.395, 57.12, 57.375], to_rgb=True)
 
 train_pipeline = [
-    dict(type='LoadOCRImageFromFile'),
+    dict(type='LoadImageFromFile', color_type='color_ignore_orientation'),
     dict(
         type='LoadTextAnnotations',
         with_bbox=True,
@@ -75,7 +75,7 @@ train_pipeline = [
         ])
 ]
 test_pipeline = [
-    dict(type='LoadOCRImageFromFile'),
+    dict(type='LoadImageFromFile', color_type='color_ignore_orientation'),
     dict(
         type='MultiScaleFlipAug',
         img_scale=(1024, 640),

--- a/configs/textdet/fcenet/fcenet_r50_fpn_1500e_icdar2015.py
+++ b/configs/textdet/fcenet/fcenet_r50_fpn_1500e_icdar2015.py
@@ -41,7 +41,7 @@ img_norm_cfg = dict(
     mean=[123.675, 116.28, 103.53], std=[58.395, 57.12, 57.375], to_rgb=True)
 
 train_pipeline = [
-    dict(type='LoadImageFromFile', color_type='color_ignore_orientation'),
+    dict(type='LoadOCRImageFromFile'),
     dict(
         type='LoadTextAnnotations',
         with_bbox=True,
@@ -80,7 +80,7 @@ train_pipeline = [
     dict(type='Collect', keys=['img', 'p3_maps', 'p4_maps', 'p5_maps'])
 ]
 test_pipeline = [
-    dict(type='LoadImageFromFile', color_type='color_ignore_orientation'),
+    dict(type='LoadOCRImageFromFile'),
     dict(
         type='MultiScaleFlipAug',
         img_scale=(2260, 2260),

--- a/configs/textdet/fcenet/fcenet_r50_fpn_1500e_icdar2015.py
+++ b/configs/textdet/fcenet/fcenet_r50_fpn_1500e_icdar2015.py
@@ -41,7 +41,7 @@ img_norm_cfg = dict(
     mean=[123.675, 116.28, 103.53], std=[58.395, 57.12, 57.375], to_rgb=True)
 
 train_pipeline = [
-    dict(type='LoadOCRImageFromFile'),
+    dict(type='LoadImageFromFile', color_type='color_ignore_orientation'),
     dict(
         type='LoadTextAnnotations',
         with_bbox=True,
@@ -80,7 +80,7 @@ train_pipeline = [
     dict(type='Collect', keys=['img', 'p3_maps', 'p4_maps', 'p5_maps'])
 ]
 test_pipeline = [
-    dict(type='LoadOCRImageFromFile'),
+    dict(type='LoadImageFromFile', color_type='color_ignore_orientation'),
     dict(
         type='MultiScaleFlipAug',
         img_scale=(2260, 2260),

--- a/configs/textdet/fcenet/fcenet_r50_fpn_1500e_icdar2015.py
+++ b/configs/textdet/fcenet/fcenet_r50_fpn_1500e_icdar2015.py
@@ -41,7 +41,7 @@ img_norm_cfg = dict(
     mean=[123.675, 116.28, 103.53], std=[58.395, 57.12, 57.375], to_rgb=True)
 
 train_pipeline = [
-    dict(type='LoadImageFromFile'),
+    dict(type='LoadImageFromFile', color_type='color_ignore_orientation'),
     dict(
         type='LoadTextAnnotations',
         with_bbox=True,
@@ -80,7 +80,7 @@ train_pipeline = [
     dict(type='Collect', keys=['img', 'p3_maps', 'p4_maps', 'p5_maps'])
 ]
 test_pipeline = [
-    dict(type='LoadImageFromFile'),
+    dict(type='LoadImageFromFile', color_type='color_ignore_orientation'),
     dict(
         type='MultiScaleFlipAug',
         img_scale=(2260, 2260),

--- a/configs/textdet/fcenet/fcenet_r50dcnv2_fpn_1500e_ctw1500.py
+++ b/configs/textdet/fcenet/fcenet_r50dcnv2_fpn_1500e_ctw1500.py
@@ -40,7 +40,7 @@ img_norm_cfg = dict(
     mean=[123.675, 116.28, 103.53], std=[58.395, 57.12, 57.375], to_rgb=True)
 
 train_pipeline = [
-    dict(type='LoadImageFromFile'),
+    dict(type='LoadImageFromFile', color_type='color_ignore_orientation'),
     dict(
         type='LoadTextAnnotations',
         with_bbox=True,
@@ -79,7 +79,7 @@ train_pipeline = [
     dict(type='Collect', keys=['img', 'p3_maps', 'p4_maps', 'p5_maps'])
 ]
 test_pipeline = [
-    dict(type='LoadImageFromFile'),
+    dict(type='LoadImageFromFile', color_type='color_ignore_orientation'),
     dict(
         type='MultiScaleFlipAug',
         img_scale=(1080, 736),

--- a/configs/textdet/fcenet/fcenet_r50dcnv2_fpn_1500e_ctw1500.py
+++ b/configs/textdet/fcenet/fcenet_r50dcnv2_fpn_1500e_ctw1500.py
@@ -40,7 +40,7 @@ img_norm_cfg = dict(
     mean=[123.675, 116.28, 103.53], std=[58.395, 57.12, 57.375], to_rgb=True)
 
 train_pipeline = [
-    dict(type='LoadOCRImageFromFile'),
+    dict(type='LoadImageFromFile', color_type='color_ignore_orientation'),
     dict(
         type='LoadTextAnnotations',
         with_bbox=True,
@@ -79,7 +79,7 @@ train_pipeline = [
     dict(type='Collect', keys=['img', 'p3_maps', 'p4_maps', 'p5_maps'])
 ]
 test_pipeline = [
-    dict(type='LoadOCRImageFromFile'),
+    dict(type='LoadImageFromFile', color_type='color_ignore_orientation'),
     dict(
         type='MultiScaleFlipAug',
         img_scale=(1080, 736),

--- a/configs/textdet/fcenet/fcenet_r50dcnv2_fpn_1500e_ctw1500.py
+++ b/configs/textdet/fcenet/fcenet_r50dcnv2_fpn_1500e_ctw1500.py
@@ -40,7 +40,7 @@ img_norm_cfg = dict(
     mean=[123.675, 116.28, 103.53], std=[58.395, 57.12, 57.375], to_rgb=True)
 
 train_pipeline = [
-    dict(type='LoadImageFromFile', color_type='color_ignore_orientation'),
+    dict(type='LoadOCRImageFromFile'),
     dict(
         type='LoadTextAnnotations',
         with_bbox=True,
@@ -79,7 +79,7 @@ train_pipeline = [
     dict(type='Collect', keys=['img', 'p3_maps', 'p4_maps', 'p5_maps'])
 ]
 test_pipeline = [
-    dict(type='LoadImageFromFile', color_type='color_ignore_orientation'),
+    dict(type='LoadOCRImageFromFile'),
     dict(
         type='MultiScaleFlipAug',
         img_scale=(1080, 736),

--- a/configs/textdet/maskrcnn/mask_rcnn_r50_fpn_160e_ctw1500.py
+++ b/configs/textdet/maskrcnn/mask_rcnn_r50_fpn_160e_ctw1500.py
@@ -9,7 +9,7 @@ img_norm_cfg = dict(
     mean=[123.675, 116.28, 103.53], std=[58.395, 57.12, 57.375], to_rgb=True)
 # img_norm_cfg = dict(mean=[0, 0, 0], std=[1, 1, 1], to_rgb=True)
 train_pipeline = [
-    dict(type='LoadImageFromFile', color_type='color_ignore_orientation'),
+    dict(type='LoadOCRImageFromFile'),
     dict(type='LoadAnnotations', with_bbox=True, with_mask=True),
     dict(
         type='ScaleAspectJitter',
@@ -29,7 +29,7 @@ train_pipeline = [
     dict(type='Collect', keys=['img', 'gt_bboxes', 'gt_labels', 'gt_masks']),
 ]
 test_pipeline = [
-    dict(type='LoadImageFromFile', color_type='color_ignore_orientation'),
+    dict(type='LoadOCRImageFromFile'),
     dict(
         type='MultiScaleFlipAug',
         # resize the long size to 1600

--- a/configs/textdet/maskrcnn/mask_rcnn_r50_fpn_160e_ctw1500.py
+++ b/configs/textdet/maskrcnn/mask_rcnn_r50_fpn_160e_ctw1500.py
@@ -9,7 +9,7 @@ img_norm_cfg = dict(
     mean=[123.675, 116.28, 103.53], std=[58.395, 57.12, 57.375], to_rgb=True)
 # img_norm_cfg = dict(mean=[0, 0, 0], std=[1, 1, 1], to_rgb=True)
 train_pipeline = [
-    dict(type='LoadOCRImageFromFile'),
+    dict(type='LoadImageFromFile', color_type='color_ignore_orientation'),
     dict(type='LoadAnnotations', with_bbox=True, with_mask=True),
     dict(
         type='ScaleAspectJitter',
@@ -29,7 +29,7 @@ train_pipeline = [
     dict(type='Collect', keys=['img', 'gt_bboxes', 'gt_labels', 'gt_masks']),
 ]
 test_pipeline = [
-    dict(type='LoadOCRImageFromFile'),
+    dict(type='LoadImageFromFile', color_type='color_ignore_orientation'),
     dict(
         type='MultiScaleFlipAug',
         # resize the long size to 1600

--- a/configs/textdet/maskrcnn/mask_rcnn_r50_fpn_160e_ctw1500.py
+++ b/configs/textdet/maskrcnn/mask_rcnn_r50_fpn_160e_ctw1500.py
@@ -4,7 +4,7 @@ _base_ = [
 ]
 
 dataset_type = 'IcdarDataset'
-data_root = 'data/ocr_dataset/det/ctw1500/'
+data_root = 'data/ctw1500/'
 img_norm_cfg = dict(
     mean=[123.675, 116.28, 103.53], std=[58.395, 57.12, 57.375], to_rgb=True)
 # img_norm_cfg = dict(mean=[0, 0, 0], std=[1, 1, 1], to_rgb=True)
@@ -45,7 +45,7 @@ test_pipeline = [
         ])
 ]
 data = dict(
-    samples_per_gpu=2,
+    samples_per_gpu=8,
     workers_per_gpu=4,
     val_dataloader=dict(samples_per_gpu=1),
     test_dataloader=dict(samples_per_gpu=1),

--- a/configs/textdet/maskrcnn/mask_rcnn_r50_fpn_160e_ctw1500.py
+++ b/configs/textdet/maskrcnn/mask_rcnn_r50_fpn_160e_ctw1500.py
@@ -4,12 +4,12 @@ _base_ = [
 ]
 
 dataset_type = 'IcdarDataset'
-data_root = 'data/ctw1500/'
+data_root = 'data/ocr_dataset/det/ctw1500/'
 img_norm_cfg = dict(
     mean=[123.675, 116.28, 103.53], std=[58.395, 57.12, 57.375], to_rgb=True)
 # img_norm_cfg = dict(mean=[0, 0, 0], std=[1, 1, 1], to_rgb=True)
 train_pipeline = [
-    dict(type='LoadImageFromFile'),
+    dict(type='LoadImageFromFile', color_type='color_ignore_orientation'),
     dict(type='LoadAnnotations', with_bbox=True, with_mask=True),
     dict(
         type='ScaleAspectJitter',
@@ -29,7 +29,7 @@ train_pipeline = [
     dict(type='Collect', keys=['img', 'gt_bboxes', 'gt_labels', 'gt_masks']),
 ]
 test_pipeline = [
-    dict(type='LoadImageFromFile'),
+    dict(type='LoadImageFromFile', color_type='color_ignore_orientation'),
     dict(
         type='MultiScaleFlipAug',
         # resize the long size to 1600
@@ -45,7 +45,7 @@ test_pipeline = [
         ])
 ]
 data = dict(
-    samples_per_gpu=8,
+    samples_per_gpu=2,
     workers_per_gpu=4,
     val_dataloader=dict(samples_per_gpu=1),
     test_dataloader=dict(samples_per_gpu=1),

--- a/configs/textdet/maskrcnn/mask_rcnn_r50_fpn_160e_icdar2015.py
+++ b/configs/textdet/maskrcnn/mask_rcnn_r50_fpn_160e_icdar2015.py
@@ -8,7 +8,7 @@ img_norm_cfg = dict(
     mean=[123.675, 116.28, 103.53], std=[58.395, 57.12, 57.375], to_rgb=True)
 # img_norm_cfg = dict(mean=[0, 0, 0], std=[1, 1, 1], to_rgb=True)
 train_pipeline = [
-    dict(type='LoadImageFromFile', color_type='color_ignore_orientation'),
+    dict(type='LoadOCRImageFromFile'),
     dict(type='LoadAnnotations', with_bbox=True, with_mask=True),
     dict(
         type='ScaleAspectJitter',
@@ -28,7 +28,7 @@ train_pipeline = [
     dict(type='Collect', keys=['img', 'gt_bboxes', 'gt_labels', 'gt_masks']),
 ]
 test_pipeline = [
-    dict(type='LoadImageFromFile', color_type='color_ignore_orientation'),
+    dict(type='LoadOCRImageFromFile'),
     dict(
         type='MultiScaleFlipAug',
         # resize the long size to 1600

--- a/configs/textdet/maskrcnn/mask_rcnn_r50_fpn_160e_icdar2015.py
+++ b/configs/textdet/maskrcnn/mask_rcnn_r50_fpn_160e_icdar2015.py
@@ -8,7 +8,7 @@ img_norm_cfg = dict(
     mean=[123.675, 116.28, 103.53], std=[58.395, 57.12, 57.375], to_rgb=True)
 # img_norm_cfg = dict(mean=[0, 0, 0], std=[1, 1, 1], to_rgb=True)
 train_pipeline = [
-    dict(type='LoadOCRImageFromFile'),
+    dict(type='LoadImageFromFile', color_type='color_ignore_orientation'),
     dict(type='LoadAnnotations', with_bbox=True, with_mask=True),
     dict(
         type='ScaleAspectJitter',
@@ -28,7 +28,7 @@ train_pipeline = [
     dict(type='Collect', keys=['img', 'gt_bboxes', 'gt_labels', 'gt_masks']),
 ]
 test_pipeline = [
-    dict(type='LoadOCRImageFromFile'),
+    dict(type='LoadImageFromFile', color_type='color_ignore_orientation'),
     dict(
         type='MultiScaleFlipAug',
         # resize the long size to 1600

--- a/configs/textdet/maskrcnn/mask_rcnn_r50_fpn_160e_icdar2015.py
+++ b/configs/textdet/maskrcnn/mask_rcnn_r50_fpn_160e_icdar2015.py
@@ -8,7 +8,7 @@ img_norm_cfg = dict(
     mean=[123.675, 116.28, 103.53], std=[58.395, 57.12, 57.375], to_rgb=True)
 # img_norm_cfg = dict(mean=[0, 0, 0], std=[1, 1, 1], to_rgb=True)
 train_pipeline = [
-    dict(type='LoadImageFromFile'),
+    dict(type='LoadImageFromFile', color_type='color_ignore_orientation'),
     dict(type='LoadAnnotations', with_bbox=True, with_mask=True),
     dict(
         type='ScaleAspectJitter',
@@ -28,7 +28,7 @@ train_pipeline = [
     dict(type='Collect', keys=['img', 'gt_bboxes', 'gt_labels', 'gt_masks']),
 ]
 test_pipeline = [
-    dict(type='LoadImageFromFile'),
+    dict(type='LoadImageFromFile', color_type='color_ignore_orientation'),
     dict(
         type='MultiScaleFlipAug',
         # resize the long size to 1600

--- a/configs/textdet/maskrcnn/mask_rcnn_r50_fpn_160e_icdar2017.py
+++ b/configs/textdet/maskrcnn/mask_rcnn_r50_fpn_160e_icdar2017.py
@@ -9,7 +9,7 @@ img_norm_cfg = dict(
     mean=[123.675, 116.28, 103.53], std=[58.395, 57.12, 57.375], to_rgb=True)
 # img_norm_cfg = dict(mean=[0, 0, 0], std=[1, 1, 1], to_rgb=True)
 train_pipeline = [
-    dict(type='LoadImageFromFile', color_type='color_ignore_orientation'),
+    dict(type='LoadOCRImageFromFile'),
     dict(type='LoadAnnotations', with_bbox=True, with_mask=True),
     dict(
         type='ScaleAspectJitter',
@@ -29,7 +29,7 @@ train_pipeline = [
     dict(type='Collect', keys=['img', 'gt_bboxes', 'gt_labels', 'gt_masks']),
 ]
 test_pipeline = [
-    dict(type='LoadImageFromFile', color_type='color_ignore_orientation'),
+    dict(type='LoadOCRImageFromFile'),
     dict(
         type='MultiScaleFlipAug',
         # resize the long size to 1600

--- a/configs/textdet/maskrcnn/mask_rcnn_r50_fpn_160e_icdar2017.py
+++ b/configs/textdet/maskrcnn/mask_rcnn_r50_fpn_160e_icdar2017.py
@@ -9,7 +9,7 @@ img_norm_cfg = dict(
     mean=[123.675, 116.28, 103.53], std=[58.395, 57.12, 57.375], to_rgb=True)
 # img_norm_cfg = dict(mean=[0, 0, 0], std=[1, 1, 1], to_rgb=True)
 train_pipeline = [
-    dict(type='LoadOCRImageFromFile'),
+    dict(type='LoadImageFromFile', color_type='color_ignore_orientation'),
     dict(type='LoadAnnotations', with_bbox=True, with_mask=True),
     dict(
         type='ScaleAspectJitter',
@@ -29,7 +29,7 @@ train_pipeline = [
     dict(type='Collect', keys=['img', 'gt_bboxes', 'gt_labels', 'gt_masks']),
 ]
 test_pipeline = [
-    dict(type='LoadOCRImageFromFile'),
+    dict(type='LoadImageFromFile', color_type='color_ignore_orientation'),
     dict(
         type='MultiScaleFlipAug',
         # resize the long size to 1600

--- a/configs/textdet/maskrcnn/mask_rcnn_r50_fpn_160e_icdar2017.py
+++ b/configs/textdet/maskrcnn/mask_rcnn_r50_fpn_160e_icdar2017.py
@@ -9,7 +9,7 @@ img_norm_cfg = dict(
     mean=[123.675, 116.28, 103.53], std=[58.395, 57.12, 57.375], to_rgb=True)
 # img_norm_cfg = dict(mean=[0, 0, 0], std=[1, 1, 1], to_rgb=True)
 train_pipeline = [
-    dict(type='LoadImageFromFile'),
+    dict(type='LoadImageFromFile', color_type='color_ignore_orientation'),
     dict(type='LoadAnnotations', with_bbox=True, with_mask=True),
     dict(
         type='ScaleAspectJitter',
@@ -29,7 +29,7 @@ train_pipeline = [
     dict(type='Collect', keys=['img', 'gt_bboxes', 'gt_labels', 'gt_masks']),
 ]
 test_pipeline = [
-    dict(type='LoadImageFromFile'),
+    dict(type='LoadImageFromFile', color_type='color_ignore_orientation'),
     dict(
         type='MultiScaleFlipAug',
         # resize the long size to 1600

--- a/configs/textdet/panet/panet_r18_fpem_ffm_600e_ctw1500.py
+++ b/configs/textdet/panet/panet_r18_fpem_ffm_600e_ctw1500.py
@@ -34,7 +34,7 @@ img_norm_cfg = dict(
 #    mean=[0, 0, 0], std=[1, 1, 1], to_rgb=True)
 
 train_pipeline = [
-    dict(type='LoadImageFromFile', color_type='color_ignore_orientation'),
+    dict(type='LoadOCRImageFromFile'),
     dict(
         type='LoadTextAnnotations',
         with_bbox=True,
@@ -66,7 +66,7 @@ train_pipeline = [
     dict(type='Collect', keys=['img', 'gt_kernels', 'gt_mask'])
 ]
 test_pipeline = [
-    dict(type='LoadImageFromFile', color_type='color_ignore_orientation'),
+    dict(type='LoadOCRImageFromFile'),
     dict(
         type='MultiScaleFlipAug',
         img_scale=(3000, 640),

--- a/configs/textdet/panet/panet_r18_fpem_ffm_600e_ctw1500.py
+++ b/configs/textdet/panet/panet_r18_fpem_ffm_600e_ctw1500.py
@@ -34,7 +34,7 @@ img_norm_cfg = dict(
 #    mean=[0, 0, 0], std=[1, 1, 1], to_rgb=True)
 
 train_pipeline = [
-    dict(type='LoadOCRImageFromFile'),
+    dict(type='LoadImageFromFile', color_type='color_ignore_orientation'),
     dict(
         type='LoadTextAnnotations',
         with_bbox=True,
@@ -66,7 +66,7 @@ train_pipeline = [
     dict(type='Collect', keys=['img', 'gt_kernels', 'gt_mask'])
 ]
 test_pipeline = [
-    dict(type='LoadOCRImageFromFile'),
+    dict(type='LoadImageFromFile', color_type='color_ignore_orientation'),
     dict(
         type='MultiScaleFlipAug',
         img_scale=(3000, 640),

--- a/configs/textdet/panet/panet_r18_fpem_ffm_600e_ctw1500.py
+++ b/configs/textdet/panet/panet_r18_fpem_ffm_600e_ctw1500.py
@@ -34,7 +34,7 @@ img_norm_cfg = dict(
 #    mean=[0, 0, 0], std=[1, 1, 1], to_rgb=True)
 
 train_pipeline = [
-    dict(type='LoadImageFromFile'),
+    dict(type='LoadImageFromFile', color_type='color_ignore_orientation'),
     dict(
         type='LoadTextAnnotations',
         with_bbox=True,
@@ -66,7 +66,7 @@ train_pipeline = [
     dict(type='Collect', keys=['img', 'gt_kernels', 'gt_mask'])
 ]
 test_pipeline = [
-    dict(type='LoadImageFromFile'),
+    dict(type='LoadImageFromFile', color_type='color_ignore_orientation'),
     dict(
         type='MultiScaleFlipAug',
         img_scale=(3000, 640),

--- a/configs/textdet/panet/panet_r18_fpem_ffm_600e_icdar2015.py
+++ b/configs/textdet/panet/panet_r18_fpem_ffm_600e_icdar2015.py
@@ -33,7 +33,7 @@ img_norm_cfg = dict(
 #    mean=[0, 0, 0], std=[1, 1, 1], to_rgb=True)
 
 train_pipeline = [
-    dict(type='LoadImageFromFile'),
+    dict(type='LoadImageFromFile', color_type='color_ignore_orientation'),
     dict(
         type='LoadTextAnnotations',
         with_bbox=True,
@@ -64,7 +64,7 @@ train_pipeline = [
     dict(type='Collect', keys=['img', 'gt_kernels', 'gt_mask'])
 ]
 test_pipeline = [
-    dict(type='LoadImageFromFile'),
+    dict(type='LoadImageFromFile', color_type='color_ignore_orientation'),
     dict(
         type='MultiScaleFlipAug',
         img_scale=(1333, 736),

--- a/configs/textdet/panet/panet_r18_fpem_ffm_600e_icdar2015.py
+++ b/configs/textdet/panet/panet_r18_fpem_ffm_600e_icdar2015.py
@@ -33,7 +33,7 @@ img_norm_cfg = dict(
 #    mean=[0, 0, 0], std=[1, 1, 1], to_rgb=True)
 
 train_pipeline = [
-    dict(type='LoadImageFromFile', color_type='color_ignore_orientation'),
+    dict(type='LoadOCRImageFromFile'),
     dict(
         type='LoadTextAnnotations',
         with_bbox=True,
@@ -64,7 +64,7 @@ train_pipeline = [
     dict(type='Collect', keys=['img', 'gt_kernels', 'gt_mask'])
 ]
 test_pipeline = [
-    dict(type='LoadImageFromFile', color_type='color_ignore_orientation'),
+    dict(type='LoadOCRImageFromFile'),
     dict(
         type='MultiScaleFlipAug',
         img_scale=(1333, 736),

--- a/configs/textdet/panet/panet_r18_fpem_ffm_600e_icdar2015.py
+++ b/configs/textdet/panet/panet_r18_fpem_ffm_600e_icdar2015.py
@@ -33,7 +33,7 @@ img_norm_cfg = dict(
 #    mean=[0, 0, 0], std=[1, 1, 1], to_rgb=True)
 
 train_pipeline = [
-    dict(type='LoadOCRImageFromFile'),
+    dict(type='LoadImageFromFile', color_type='color_ignore_orientation'),
     dict(
         type='LoadTextAnnotations',
         with_bbox=True,
@@ -64,7 +64,7 @@ train_pipeline = [
     dict(type='Collect', keys=['img', 'gt_kernels', 'gt_mask'])
 ]
 test_pipeline = [
-    dict(type='LoadOCRImageFromFile'),
+    dict(type='LoadImageFromFile', color_type='color_ignore_orientation'),
     dict(
         type='MultiScaleFlipAug',
         img_scale=(1333, 736),

--- a/configs/textdet/panet/panet_r50_fpem_ffm_600e_icdar2017.py
+++ b/configs/textdet/panet/panet_r50_fpem_ffm_600e_icdar2017.py
@@ -28,7 +28,7 @@ data_root = 'data/icdar2017/'
 img_norm_cfg = dict(
     mean=[123.675, 116.28, 103.53], std=[58.395, 57.12, 57.375], to_rgb=True)
 train_pipeline = [
-    dict(type='LoadOCRImageFromFile'),
+    dict(type='LoadImageFromFile', color_type='color_ignore_orientation'),
     dict(
         type='LoadTextAnnotations',
         with_bbox=True,
@@ -59,7 +59,7 @@ train_pipeline = [
     dict(type='Collect', keys=['img', 'gt_kernels', 'gt_mask'])
 ]
 test_pipeline = [
-    dict(type='LoadOCRImageFromFile'),
+    dict(type='LoadImageFromFile', color_type='color_ignore_orientation'),
     dict(
         type='MultiScaleFlipAug',
         img_scale=(1333, 800),

--- a/configs/textdet/panet/panet_r50_fpem_ffm_600e_icdar2017.py
+++ b/configs/textdet/panet/panet_r50_fpem_ffm_600e_icdar2017.py
@@ -28,7 +28,7 @@ data_root = 'data/icdar2017/'
 img_norm_cfg = dict(
     mean=[123.675, 116.28, 103.53], std=[58.395, 57.12, 57.375], to_rgb=True)
 train_pipeline = [
-    dict(type='LoadImageFromFile', color_type='color_ignore_orientation'),
+    dict(type='LoadOCRImageFromFile'),
     dict(
         type='LoadTextAnnotations',
         with_bbox=True,
@@ -59,7 +59,7 @@ train_pipeline = [
     dict(type='Collect', keys=['img', 'gt_kernels', 'gt_mask'])
 ]
 test_pipeline = [
-    dict(type='LoadImageFromFile', color_type='color_ignore_orientation'),
+    dict(type='LoadOCRImageFromFile'),
     dict(
         type='MultiScaleFlipAug',
         img_scale=(1333, 800),

--- a/configs/textdet/panet/panet_r50_fpem_ffm_600e_icdar2017.py
+++ b/configs/textdet/panet/panet_r50_fpem_ffm_600e_icdar2017.py
@@ -28,7 +28,7 @@ data_root = 'data/icdar2017/'
 img_norm_cfg = dict(
     mean=[123.675, 116.28, 103.53], std=[58.395, 57.12, 57.375], to_rgb=True)
 train_pipeline = [
-    dict(type='LoadImageFromFile'),
+    dict(type='LoadImageFromFile', color_type='color_ignore_orientation'),
     dict(
         type='LoadTextAnnotations',
         with_bbox=True,
@@ -59,7 +59,7 @@ train_pipeline = [
     dict(type='Collect', keys=['img', 'gt_kernels', 'gt_mask'])
 ]
 test_pipeline = [
-    dict(type='LoadImageFromFile'),
+    dict(type='LoadImageFromFile', color_type='color_ignore_orientation'),
     dict(
         type='MultiScaleFlipAug',
         img_scale=(1333, 800),

--- a/configs/textdet/psenet/psenet_r50_fpnf_600e_ctw1500.py
+++ b/configs/textdet/psenet/psenet_r50_fpnf_600e_ctw1500.py
@@ -39,7 +39,7 @@ img_norm_cfg = dict(
     mean=[123.675, 116.28, 103.53], std=[58.395, 57.12, 57.375], to_rgb=True)
 
 train_pipeline = [
-    dict(type='LoadImageFromFile'),
+    dict(type='LoadImageFromFile', color_type='color_ignore_orientation'),
     dict(
         type='LoadTextAnnotations',
         with_bbox=True,
@@ -72,7 +72,7 @@ train_pipeline = [
     dict(type='Collect', keys=['img', 'gt_kernels', 'gt_mask'])
 ]
 test_pipeline = [
-    dict(type='LoadImageFromFile'),
+    dict(type='LoadImageFromFile', color_type='color_ignore_orientation'),
     dict(
         type='MultiScaleFlipAug',
         img_scale=(1280, 1280),

--- a/configs/textdet/psenet/psenet_r50_fpnf_600e_ctw1500.py
+++ b/configs/textdet/psenet/psenet_r50_fpnf_600e_ctw1500.py
@@ -39,7 +39,7 @@ img_norm_cfg = dict(
     mean=[123.675, 116.28, 103.53], std=[58.395, 57.12, 57.375], to_rgb=True)
 
 train_pipeline = [
-    dict(type='LoadOCRImageFromFile'),
+    dict(type='LoadImageFromFile', color_type='color_ignore_orientation'),
     dict(
         type='LoadTextAnnotations',
         with_bbox=True,
@@ -72,7 +72,7 @@ train_pipeline = [
     dict(type='Collect', keys=['img', 'gt_kernels', 'gt_mask'])
 ]
 test_pipeline = [
-    dict(type='LoadOCRImageFromFile'),
+    dict(type='LoadImageFromFile', color_type='color_ignore_orientation'),
     dict(
         type='MultiScaleFlipAug',
         img_scale=(1280, 1280),

--- a/configs/textdet/psenet/psenet_r50_fpnf_600e_ctw1500.py
+++ b/configs/textdet/psenet/psenet_r50_fpnf_600e_ctw1500.py
@@ -39,7 +39,7 @@ img_norm_cfg = dict(
     mean=[123.675, 116.28, 103.53], std=[58.395, 57.12, 57.375], to_rgb=True)
 
 train_pipeline = [
-    dict(type='LoadImageFromFile', color_type='color_ignore_orientation'),
+    dict(type='LoadOCRImageFromFile'),
     dict(
         type='LoadTextAnnotations',
         with_bbox=True,
@@ -72,7 +72,7 @@ train_pipeline = [
     dict(type='Collect', keys=['img', 'gt_kernels', 'gt_mask'])
 ]
 test_pipeline = [
-    dict(type='LoadImageFromFile', color_type='color_ignore_orientation'),
+    dict(type='LoadOCRImageFromFile'),
     dict(
         type='MultiScaleFlipAug',
         img_scale=(1280, 1280),

--- a/configs/textdet/psenet/psenet_r50_fpnf_600e_icdar2015.py
+++ b/configs/textdet/psenet/psenet_r50_fpnf_600e_icdar2015.py
@@ -39,7 +39,7 @@ img_norm_cfg = dict(
     mean=[123.675, 116.28, 103.53], std=[58.395, 57.12, 57.375], to_rgb=True)
 
 train_pipeline = [
-    dict(type='LoadOCRImageFromFile'),
+    dict(type='LoadImageFromFile', color_type='color_ignore_orientation'),
     dict(
         type='LoadTextAnnotations',
         with_bbox=True,
@@ -72,7 +72,7 @@ train_pipeline = [
     dict(type='Collect', keys=['img', 'gt_kernels', 'gt_mask'])
 ]
 test_pipeline = [
-    dict(type='LoadOCRImageFromFile'),
+    dict(type='LoadImageFromFile', color_type='color_ignore_orientation'),
     dict(
         type='MultiScaleFlipAug',
         img_scale=(2240, 2200),

--- a/configs/textdet/psenet/psenet_r50_fpnf_600e_icdar2015.py
+++ b/configs/textdet/psenet/psenet_r50_fpnf_600e_icdar2015.py
@@ -39,7 +39,7 @@ img_norm_cfg = dict(
     mean=[123.675, 116.28, 103.53], std=[58.395, 57.12, 57.375], to_rgb=True)
 
 train_pipeline = [
-    dict(type='LoadImageFromFile'),
+    dict(type='LoadImageFromFile', color_type='color_ignore_orientation'),
     dict(
         type='LoadTextAnnotations',
         with_bbox=True,
@@ -72,7 +72,7 @@ train_pipeline = [
     dict(type='Collect', keys=['img', 'gt_kernels', 'gt_mask'])
 ]
 test_pipeline = [
-    dict(type='LoadImageFromFile'),
+    dict(type='LoadImageFromFile', color_type='color_ignore_orientation'),
     dict(
         type='MultiScaleFlipAug',
         img_scale=(2240, 2200),

--- a/configs/textdet/psenet/psenet_r50_fpnf_600e_icdar2015.py
+++ b/configs/textdet/psenet/psenet_r50_fpnf_600e_icdar2015.py
@@ -39,7 +39,7 @@ img_norm_cfg = dict(
     mean=[123.675, 116.28, 103.53], std=[58.395, 57.12, 57.375], to_rgb=True)
 
 train_pipeline = [
-    dict(type='LoadImageFromFile', color_type='color_ignore_orientation'),
+    dict(type='LoadOCRImageFromFile'),
     dict(
         type='LoadTextAnnotations',
         with_bbox=True,
@@ -72,7 +72,7 @@ train_pipeline = [
     dict(type='Collect', keys=['img', 'gt_kernels', 'gt_mask'])
 ]
 test_pipeline = [
-    dict(type='LoadImageFromFile', color_type='color_ignore_orientation'),
+    dict(type='LoadOCRImageFromFile'),
     dict(
         type='MultiScaleFlipAug',
         img_scale=(2240, 2200),

--- a/configs/textdet/psenet/psenet_r50_fpnf_600e_icdar2017.py
+++ b/configs/textdet/psenet/psenet_r50_fpnf_600e_icdar2017.py
@@ -34,7 +34,7 @@ img_norm_cfg = dict(
     mean=[123.675, 116.28, 103.53], std=[58.395, 57.12, 57.375], to_rgb=True)
 
 train_pipeline = [
-    dict(type='LoadOCRImageFromFile'),
+    dict(type='LoadImageFromFile', color_type='color_ignore_orientation'),
     dict(
         type='LoadTextAnnotations',
         with_bbox=True,
@@ -67,7 +67,7 @@ train_pipeline = [
     dict(type='Collect', keys=['img', 'gt_kernels', 'gt_mask'])
 ]
 test_pipeline = [
-    dict(type='LoadOCRImageFromFile'),
+    dict(type='LoadImageFromFile', color_type='color_ignore_orientation'),
     dict(
         type='MultiScaleFlipAug',
         img_scale=(2240, 2200),

--- a/configs/textdet/psenet/psenet_r50_fpnf_600e_icdar2017.py
+++ b/configs/textdet/psenet/psenet_r50_fpnf_600e_icdar2017.py
@@ -34,7 +34,7 @@ img_norm_cfg = dict(
     mean=[123.675, 116.28, 103.53], std=[58.395, 57.12, 57.375], to_rgb=True)
 
 train_pipeline = [
-    dict(type='LoadImageFromFile'),
+    dict(type='LoadImageFromFile', color_type='color_ignore_orientation'),
     dict(
         type='LoadTextAnnotations',
         with_bbox=True,
@@ -67,7 +67,7 @@ train_pipeline = [
     dict(type='Collect', keys=['img', 'gt_kernels', 'gt_mask'])
 ]
 test_pipeline = [
-    dict(type='LoadImageFromFile'),
+    dict(type='LoadImageFromFile', color_type='color_ignore_orientation'),
     dict(
         type='MultiScaleFlipAug',
         img_scale=(2240, 2200),

--- a/configs/textdet/psenet/psenet_r50_fpnf_600e_icdar2017.py
+++ b/configs/textdet/psenet/psenet_r50_fpnf_600e_icdar2017.py
@@ -34,7 +34,7 @@ img_norm_cfg = dict(
     mean=[123.675, 116.28, 103.53], std=[58.395, 57.12, 57.375], to_rgb=True)
 
 train_pipeline = [
-    dict(type='LoadImageFromFile', color_type='color_ignore_orientation'),
+    dict(type='LoadOCRImageFromFile'),
     dict(
         type='LoadTextAnnotations',
         with_bbox=True,
@@ -67,7 +67,7 @@ train_pipeline = [
     dict(type='Collect', keys=['img', 'gt_kernels', 'gt_mask'])
 ]
 test_pipeline = [
-    dict(type='LoadImageFromFile', color_type='color_ignore_orientation'),
+    dict(type='LoadOCRImageFromFile'),
     dict(
         type='MultiScaleFlipAug',
         img_scale=(2240, 2200),

--- a/configs/textdet/textsnake/textsnake_r50_fpn_unet_1200e_ctw1500.py
+++ b/configs/textdet/textsnake/textsnake_r50_fpn_unet_1200e_ctw1500.py
@@ -30,7 +30,7 @@ img_norm_cfg = dict(
     mean=[123.675, 116.28, 103.53], std=[58.395, 57.12, 57.375], to_rgb=True)
 
 train_pipeline = [
-    dict(type='LoadImageFromFile'),
+    dict(type='LoadImageFromFile', color_type='color_ignore_orientation'),
     dict(
         type='LoadTextAnnotations',
         with_bbox=True,
@@ -77,7 +77,7 @@ train_pipeline = [
         ])
 ]
 test_pipeline = [
-    dict(type='LoadImageFromFile'),
+    dict(type='LoadImageFromFile', color_type='color_ignore_orientation'),
     dict(
         type='MultiScaleFlipAug',
         img_scale=(1333, 736),

--- a/configs/textdet/textsnake/textsnake_r50_fpn_unet_1200e_ctw1500.py
+++ b/configs/textdet/textsnake/textsnake_r50_fpn_unet_1200e_ctw1500.py
@@ -30,7 +30,7 @@ img_norm_cfg = dict(
     mean=[123.675, 116.28, 103.53], std=[58.395, 57.12, 57.375], to_rgb=True)
 
 train_pipeline = [
-    dict(type='LoadOCRImageFromFile'),
+    dict(type='LoadImageFromFile', color_type='color_ignore_orientation'),
     dict(
         type='LoadTextAnnotations',
         with_bbox=True,
@@ -77,7 +77,7 @@ train_pipeline = [
         ])
 ]
 test_pipeline = [
-    dict(type='LoadOCRImageFromFile'),
+    dict(type='LoadImageFromFile', color_type='color_ignore_orientation'),
     dict(
         type='MultiScaleFlipAug',
         img_scale=(1333, 736),

--- a/configs/textdet/textsnake/textsnake_r50_fpn_unet_1200e_ctw1500.py
+++ b/configs/textdet/textsnake/textsnake_r50_fpn_unet_1200e_ctw1500.py
@@ -30,7 +30,7 @@ img_norm_cfg = dict(
     mean=[123.675, 116.28, 103.53], std=[58.395, 57.12, 57.375], to_rgb=True)
 
 train_pipeline = [
-    dict(type='LoadImageFromFile', color_type='color_ignore_orientation'),
+    dict(type='LoadOCRImageFromFile'),
     dict(
         type='LoadTextAnnotations',
         with_bbox=True,
@@ -77,7 +77,7 @@ train_pipeline = [
         ])
 ]
 test_pipeline = [
-    dict(type='LoadImageFromFile', color_type='color_ignore_orientation'),
+    dict(type='LoadOCRImageFromFile'),
     dict(
         type='MultiScaleFlipAug',
         img_scale=(1333, 736),

--- a/configs/textrecog/crnn/crnn_academic_dataset.py
+++ b/configs/textrecog/crnn/crnn_academic_dataset.py
@@ -42,7 +42,7 @@ total_epochs = 5
 img_norm_cfg = dict(mean=[0.5], std=[0.5])
 
 train_pipeline = [
-    dict(type='LoadImageFromFile', color_type='grayscale'),
+    dict(type='LoadOCRImageFromFile', color_type='grayscale'),
     dict(
         type='ResizeOCR',
         height=32,
@@ -59,7 +59,7 @@ train_pipeline = [
         ]),
 ]
 test_pipeline = [
-    dict(type='LoadImageFromFile', color_type='grayscale'),
+    dict(type='LoadOCRImageFromFile', color_type='grayscale'),
     dict(
         type='ResizeOCR',
         height=32,

--- a/configs/textrecog/crnn/crnn_academic_dataset.py
+++ b/configs/textrecog/crnn/crnn_academic_dataset.py
@@ -42,7 +42,7 @@ total_epochs = 5
 img_norm_cfg = dict(mean=[0.5], std=[0.5])
 
 train_pipeline = [
-    dict(type='LoadOCRImageFromFile', color_type='grayscale'),
+    dict(type='LoadImageFromFile', color_type='grayscale'),
     dict(
         type='ResizeOCR',
         height=32,
@@ -59,7 +59,7 @@ train_pipeline = [
         ]),
 ]
 test_pipeline = [
-    dict(type='LoadOCRImageFromFile', color_type='grayscale'),
+    dict(type='LoadImageFromFile', color_type='grayscale'),
     dict(
         type='ResizeOCR',
         height=32,

--- a/docs/datasets.md
+++ b/docs/datasets.md
@@ -43,15 +43,15 @@ The structure of the text detection dataset directory is organized as follows.
 │   └── instances_training.json
 ```
 
-|  Dataset  |                             Images                             |                                                                                      |                                                                                                        |            Annotation Files             |                                                                                                |
+|Dataset|Images|                                                                                      |  Annotation Files                                                                                                      |                         |                                                                                                |
 | :-------: | :------------------------------------------------------------: | :----------------------------------------------------------------------------------: | :----------------------------------------------------------------------------------------------------: | :-------------------------------------: | :--------------------------------------------------------------------------------------------: |
-|      |                                                                |                                                                                      |                                                training                                                |               validation                |                                            testing                                             |       |
-|  CTW1500  | [homepage](https://github.com/Yuliang-Liu/Curve-Text-Detector) |                                        |                    -                    |                    -                    |                    -                    |
-| ICDAR2015 | [homepage](https://rrc.cvc.uab.es/?ch=4&com=downloads)     |                                                                                      | [instances_training.json](https://download.openmmlab.com/mmocr/data/icdar2015/instances_training.json) |                    -                    | [instances_test.json](https://download.openmmlab.com/mmocr/data/icdar2015/instances_test.json) |
-| ICDAR2017 | [homepage](https://rrc.cvc.uab.es/?ch=8&com=downloads)     | [renamed_imgs](https://download.openmmlab.com/mmocr/data/icdar2017/renamed_imgs.tar) | [instances_training.json](https://download.openmmlab.com/mmocr/data/icdar2017/instances_training.json) | [instances_val.json](https://download.openmmlab.com/mmocr/data/icdar2017/instances_val.json) | - |       |       |
-| Synthtext | [homepage](https://www.robots.ox.ac.uk/~vgg/data/scenetext/)  |                                                                                      | [instances_training.lmdb](https://download.openmmlab.com/mmocr/data/synthtext/instances_training.lmdb) |                    -                    |
-| TextOCR | [homepage](https://textvqa.org/textocr/dataset)  |                                                                                      | - |                    -                    | -
-| Totaltext | [homepage](https://github.com/cs-chan/Total-Text-Dataset)  |                                                                                      | - |                    -                    | -
+|      |                                                                                      |                                                training                                                |               validation                |                                            testing                                             |       |
+|  CTW1500  | [homepage](https://github.com/Yuliang-Liu/Curve-Text-Detector) |                    -                    |                    -                    |                    -                    |
+| ICDAR2015 | [homepage](https://rrc.cvc.uab.es/?ch=4&com=downloads)     | [instances_training.json](https://download.openmmlab.com/mmocr/data/icdar2015/instances_training.json) |                    -                    | [instances_test.json](https://download.openmmlab.com/mmocr/data/icdar2015/instances_test.json) |
+| ICDAR2017 | [homepage](https://rrc.cvc.uab.es/?ch=8&com=downloads)     | [instances_training.json](https://download.openmmlab.com/mmocr/data/icdar2017/instances_training.json) | [instances_val.json](https://download.openmmlab.com/mmocr/data/icdar2017/instances_val.json) | - |       |       |
+| Synthtext | [homepage](https://www.robots.ox.ac.uk/~vgg/data/scenetext/)  | [instances_training.lmdb](https://download.openmmlab.com/mmocr/data/synthtext/instances_training.lmdb) |                    -                    | - |
+| TextOCR | [homepage](https://textvqa.org/textocr/dataset)  | - |                    -                    | -
+| Totaltext | [homepage](https://github.com/cs-chan/Total-Text-Dataset)  | - |                    -                    | -
 
 - For `icdar2015`:
   - Step1: Download `ch4_training_images.zip`, `ch4_test_images.zip`, `ch4_training_localization_transcription_gt.zip`, `Challenge4_Test_Task1_GT.zip` from [homepage](https://rrc.cvc.uab.es/?ch=4&com=downloads)
@@ -73,7 +73,7 @@ The structure of the text detection dataset directory is organized as follows.
   ```
 
 - For `icdar2017`:
-  - To avoid the effect of rotation when load `jpg` with opencv, We provide re-saved `png` format image in [renamed_images](https://download.openmmlab.com/mmocr/data/icdar2017/renamed_imgs.tar). You can copy these images to `imgs`.
+  - Follow similar steps as above.
 
 - For `ctw1500`:
   - Step1: Download `train_images.zip`, `test_images.zip`, `train_labels.zip`, `test_labels.zip` from [github](https://github.com/Yuliang-Liu/Curve-Text-Detector)

--- a/docs/datasets.md
+++ b/docs/datasets.md
@@ -53,6 +53,10 @@ The structure of the text detection dataset directory is organized as follows.
 | TextOCR | [homepage](https://textvqa.org/textocr/dataset)  | - |                    -                    | -
 | Totaltext | [homepage](https://github.com/cs-chan/Total-Text-Dataset)  | - |                    -                    | -
 
+**Note: For users who want to train models on CTW1500, ICDAR 2015/2017, and Totaltext dataset,** there might be some images containing orientation info in EXIF data. The default OpenCV
+backend used in MMCV would read them and apply the rotation on the images.  However, their gold annotations are made on the raw pixels, and such
+inconsistency results in false examples in the training set. Therefore, users should use `dict(type='LoadImageFromFile', color_type='color_ignore_orientation')` in pipelines to change MMCV's default loading behaviour. (see [DBNet's config](https://github.com/open-mmlab/mmocr/blob/main/configs/textdet/dbnet/dbnet_r18_fpnc_1200e_icdar2015.py) for example)
+
 - For `icdar2015`:
   - Step1: Download `ch4_training_images.zip`, `ch4_test_images.zip`, `ch4_training_localization_transcription_gt.zip`, `Challenge4_Test_Task1_GT.zip` from [homepage](https://rrc.cvc.uab.es/?ch=4&com=downloads)
   - Step2:

--- a/docs_zh_CN/datasets.md
+++ b/docs_zh_CN/datasets.md
@@ -33,15 +33,15 @@
 │   └── instances_training.json
 ```
 
-|  数据集名称  |                             数据图片                             |                                      补充数据                                     |                                                                                                     |               标注文件                  |                                                                                                |
-| :---------: | :----------------------------------------------------------: | :----------------------------------------------------------------------------------: | :----------------------------------------------------------------------------------------------------: | :-------------------------------------: | :--------------------------------------------------------------------------------------------: |
-|           |                                                                |                                                                                      |                                                训练集 (training)                                                |               验证集 (validation)                |                                           测试集 (testing)                                             |       |
-|  CTW1500  | [下载地址](https://github.com/Yuliang-Liu/Curve-Text-Detector) |                                        |                    -                    |                    -                    |                    -                    |
-| ICDAR2015 | [下载地址](https://rrc.cvc.uab.es/?ch=4&com=downloads)     |                                                                                      | [instances_training.json](https://download.openmmlab.com/mmocr/data/icdar2015/instances_training.json) |                    -                    | [instances_test.json](https://download.openmmlab.com/mmocr/data/icdar2015/instances_test.json) |
-| ICDAR2017 | [下载地址](https://rrc.cvc.uab.es/?ch=8&com=downloads)     | [renamed_imgs](https://download.openmmlab.com/mmocr/data/icdar2017/renamed_imgs.tar) | [instances_training.json](https://download.openmmlab.com/mmocr/data/icdar2017/instances_training.json) | [instances_val.json](https://download.openmmlab.com/mmocr/data/icdar2017/instances_val.json) | - |       |       |
-| Synthtext | [下载地址](https://www.robots.ox.ac.uk/~vgg/data/scenetext/)  |                                                                                      | [instances_training.lmdb](https://download.openmmlab.com/mmocr/data/synthtext/instances_training.lmdb) |                    -                    |
-| TextOCR | [下载地址](https://textvqa.org/textocr/dataset)  |                                                                                      | - |                    -                    | -
-| Totaltext | [下载地址](https://github.com/cs-chan/Total-Text-Dataset)  |                                                                                      | - |                    -                    | -
+|  数据集名称  |                             数据图片                             |                                                                                                     |               标注文件                  |                                                                                                |
+| :---------: | :----------------------------------------------------------: | :----------------------------------------------------------------------------------------------------: | :-------------------------------------: | :--------------------------------------------------------------------------------------------: |
+|           |                                                                                      |                                                训练集 (training)                                                |               验证集 (validation)                |                                           测试集 (testing)                                             |       |
+|  CTW1500  | [下载地址](https://github.com/Yuliang-Liu/Curve-Text-Detector) |                    -                    |                    -                    |                    -                    |
+| ICDAR2015 | [下载地址](https://rrc.cvc.uab.es/?ch=4&com=downloads)     | [instances_training.json](https://download.openmmlab.com/mmocr/data/icdar2015/instances_training.json) |                    -                    | [instances_test.json](https://download.openmmlab.com/mmocr/data/icdar2015/instances_test.json) |
+| ICDAR2017 | [下载地址](https://rrc.cvc.uab.es/?ch=8&com=downloads)     | [instances_training.json](https://download.openmmlab.com/mmocr/data/icdar2017/instances_training.json) | [instances_val.json](https://download.openmmlab.com/mmocr/data/icdar2017/instances_val.json) | - |       |       |
+| Synthtext | [下载地址](https://www.robots.ox.ac.uk/~vgg/data/scenetext/)  | [instances_training.lmdb](https://download.openmmlab.com/mmocr/data/synthtext/instances_training.lmdb) |                    -                    | - |
+| TextOCR | [下载地址](https://textvqa.org/textocr/dataset)  | - |                    -                    | -
+| Totaltext | [下载地址](https://github.com/cs-chan/Total-Text-Dataset)  | - |                    -                    | -
 
 - `icdar2015` 数据集：
   - 第一步：从[下载地址](https://rrc.cvc.uab.es/?ch=4&com=downloads)下载 `ch4_training_images.zip`、`ch4_test_images.zip`、`ch4_training_localization_transcription_gt.zip`、`Challenge4_Test_Task1_GT.zip` 四个文件，分别对应训练集数据、测试集数据、训练集标注、测试集标注。
@@ -62,7 +62,7 @@
   ```
 
 - `icdar2017` 数据集：
-  - 由于使用 opencv 加载 `.jpg` 文件时有旋转失真，我们把原数据集中的图片转换为 `.png` 格式，在这里下载：[renamed_images](https://download.openmmlab.com/mmocr/data/icdar2017/renamed_imgs.tar)。下载后，把 `.png` 图片复制到 `imgs` 文件夹里.
+  - 与上述步骤类似。
 
 - `ctw1500` 数据集：
   - 第一步：执行以下命令，从 [下载地址](https://github.com/Yuliang-Liu/Curve-Text-Detector) 下载 `train_images.zip`，`test_images.zip`，`train_labels.zip`，`test_labels.zip` 四个文件并配置到对应目录：

--- a/docs_zh_CN/datasets.md
+++ b/docs_zh_CN/datasets.md
@@ -43,6 +43,8 @@
 | TextOCR | [下载地址](https://textvqa.org/textocr/dataset)  | - |                    -                    | -
 | Totaltext | [下载地址](https://github.com/cs-chan/Total-Text-Dataset)  | - |                    -                    | -
 
+**注意：若用户需要在 CTW1500, ICDAR 2015/2017 或 Totaltext 数据集上训练模型**, 请注意这些数据集中有部分图片的 EXIF 信息里保存着方向信息。MMCV 采用的 OpenCV 后端会默认根据方向信息对图片进行旋转；而由于数据集的标注是在原图片上进行的，这种冲突会使得部分训练样本失效。因此，用户应该在配置 pipeline 时使用 `dict(type='LoadImageFromFile', color_type='color_ignore_orientation')` 以避免 MMCV 的这一行为。（配置文件可参考 [DBNet](https://github.com/open-mmlab/mmocr/blob/main/configs/textdet/dbnet/dbnet_r18_fpnc_1200e_icdar2015.py)）
+
 - `icdar2015` 数据集：
   - 第一步：从[下载地址](https://rrc.cvc.uab.es/?ch=4&com=downloads)下载 `ch4_training_images.zip`、`ch4_test_images.zip`、`ch4_training_localization_transcription_gt.zip`、`Challenge4_Test_Task1_GT.zip` 四个文件，分别对应训练集数据、测试集数据、训练集标注、测试集标注。
   - 第二步：运行以下命令，移动数据集到对应文件夹

--- a/mmocr/datasets/pipelines/loading.py
+++ b/mmocr/datasets/pipelines/loading.py
@@ -103,24 +103,3 @@ class LoadImageFromNdarray(LoadImageFromFile):
         results['ori_shape'] = img.shape
         results['img_fields'] = ['img']
         return results
-
-
-@PIPELINES.register_module()
-class LoadOCRImageFromFile(LoadImageFromFile):
-    """Load an image from file and ignore orientation info by default.
-
-    The interface is the same as :obj:`LoadImageFromFile`, but the default
-    loading type is `color_ignore_orientation` (see MMCV's documentation
-    on `imread` for details), which is specifically customized for OCR
-    datasets.
-
-    In some OCR datasets, including `ctw1500` and `icdar2017`, there are some
-    images containing orientation info in  EXIF data. The default OpenCV
-    backend used in MMCV would read them and apply the rotation on the images.
-    However, their associated annotations are made on the raw pixels, and such
-    inconsistency results in wrong examples during training. This module
-    addresses this problem by changing MMCV's default loading behaviour.
-    """
-
-    def __init__(self, color_type='color_ignore_orientation', **kwargs):
-        super().__init__(color_type=color_type, **kwargs)

--- a/mmocr/datasets/pipelines/loading.py
+++ b/mmocr/datasets/pipelines/loading.py
@@ -103,3 +103,24 @@ class LoadImageFromNdarray(LoadImageFromFile):
         results['ori_shape'] = img.shape
         results['img_fields'] = ['img']
         return results
+
+
+@PIPELINES.register_module()
+class LoadOCRImageFromFile(LoadImageFromFile):
+    """Load an image from file and ignores orientation info by default.
+
+    The interface is the same as :obj:`LoadImageFromFile`, but the default
+    loading type is `color_ignore_orientation` (see MMCV's documentation
+    on `imread` for details), which is specifically customized for OCR
+    datasets.
+
+    In some OCR datasets, including `ctw1500` and `icdar2017`, there are some
+    images containing orientation info in  EXIF data. The default OpenCV
+    backend used in MMCV would read them and apply the rotation on the images.
+    However, their associated annotations are made on the raw pixels, and such
+    inconsistency results in wrong examples during training. This module
+    addresses this problem by changing MMCV's default loading behaviour.
+    """
+
+    def __init__(self, color_type='color_ignore_orientation', **kwargs):
+        super().__init__(color_type=color_type, **kwargs)

--- a/mmocr/datasets/pipelines/loading.py
+++ b/mmocr/datasets/pipelines/loading.py
@@ -107,7 +107,7 @@ class LoadImageFromNdarray(LoadImageFromFile):
 
 @PIPELINES.register_module()
 class LoadOCRImageFromFile(LoadImageFromFile):
-    """Load an image from file and ignores orientation info by default.
+    """Load an image from file and ignore orientation info by default.
 
     The interface is the same as :obj:`LoadImageFromFile`, but the default
     loading type is `color_ignore_orientation` (see MMCV's documentation

--- a/tools/data/textdet/ctw1500_converter.py
+++ b/tools/data/textdet/ctw1500_converter.py
@@ -8,8 +8,7 @@ import mmcv
 import numpy as np
 from shapely.geometry import Polygon
 
-from mmocr.utils import (convert_annotations, drop_orientation, is_not_png,
-                         list_from_file)
+from mmocr.utils import convert_annotations, list_from_file
 
 
 def collect_files(img_dir, gt_dir, split):
@@ -35,10 +34,6 @@ def collect_files(img_dir, gt_dir, split):
     imgs_list = []
     for suffix in suffixes:
         imgs_list.extend(glob.glob(osp.join(img_dir, '*' + suffix)))
-
-    imgs_list = [
-        drop_orientation(f) if is_not_png(f) else f for f in imgs_list
-    ]
 
     files = []
     if split == 'training':
@@ -169,10 +164,6 @@ def load_img_info(files, split):
     img_file, gt_file = files
     # read imgs with ignoring orientations
     img = mmcv.imread(img_file, 'unchanged')
-    # read imgs with orientations as dataloader does when training and testing
-    img_color = mmcv.imread(img_file, 'color')
-    # make sure imgs have no orientations info, or annotation gt is wrong.
-    assert img.shape[0:2] == img_color.shape[0:2]
 
     split_name = osp.basename(osp.dirname(img_file))
     img_info = dict(

--- a/tools/data/textdet/icdar_converter.py
+++ b/tools/data/textdet/icdar_converter.py
@@ -7,8 +7,7 @@ import mmcv
 import numpy as np
 from shapely.geometry import Polygon
 
-from mmocr.utils import (convert_annotations, drop_orientation, is_not_png,
-                         list_from_file)
+from mmocr.utils import convert_annotations, list_from_file
 
 
 def collect_files(img_dir, gt_dir):
@@ -32,10 +31,6 @@ def collect_files(img_dir, gt_dir):
     imgs_list = []
     for suffix in suffixes:
         imgs_list.extend(glob.glob(osp.join(img_dir, '*' + suffix)))
-
-    imgs_list = [
-        drop_orientation(f) if is_not_png(f) else f for f in imgs_list
-    ]
 
     files = []
     for img_file in imgs_list:
@@ -91,10 +86,6 @@ def load_img_info(files, dataset):
     img_file, gt_file = files
     # read imgs with ignoring orientations
     img = mmcv.imread(img_file, 'unchanged')
-    # read imgs with orientations as dataloader does when training and testing
-    img_color = mmcv.imread(img_file, 'color')
-    # make sure imgs have no orientations info, or annotation gt is wrong.
-    assert img.shape[0:2] == img_color.shape[0:2]
 
     if dataset == 'icdar2017':
         gt_list = list_from_file(gt_file)

--- a/tools/data/textdet/totaltext_converter.py
+++ b/tools/data/textdet/totaltext_converter.py
@@ -11,7 +11,7 @@ import scipy.io as scio
 import yaml
 from shapely.geometry import Polygon
 
-from mmocr.utils import convert_annotations, drop_orientation, is_not_png
+from mmocr.utils import convert_annotations
 
 
 def collect_files(img_dir, gt_dir, split):
@@ -38,8 +38,7 @@ def collect_files(img_dir, gt_dir, split):
     for suffix in suffixes:
         imgs_list.extend(glob.glob(osp.join(img_dir, '*' + suffix)))
 
-    imgs_list = sorted(
-        [drop_orientation(f) if is_not_png(f) else f for f in imgs_list])
+    imgs_list = sorted(imgs_list)
     ann_list = sorted(
         [osp.join(gt_dir, gt_file) for gt_file in os.listdir(gt_dir)])
 

--- a/tools/data/textrecog/totaltext_converter.py
+++ b/tools/data/textrecog/totaltext_converter.py
@@ -11,7 +11,6 @@ import yaml
 from shapely.geometry import Polygon
 
 from mmocr.datasets.pipelines.crop import crop_img
-from mmocr.utils import drop_orientation, is_not_png
 from mmocr.utils.fileio import list_to_file
 
 
@@ -39,8 +38,7 @@ def collect_files(img_dir, gt_dir, split):
     for suffix in suffixes:
         imgs_list.extend(glob.glob(osp.join(img_dir, '*' + suffix)))
 
-    imgs_list = sorted(
-        [drop_orientation(f) if is_not_png(f) else f for f in imgs_list])
+    imgs_list = sorted(imgs_list)
     ann_list = sorted(
         [osp.join(gt_dir, gt_file) for gt_file in os.listdir(gt_dir)])
 
@@ -318,10 +316,6 @@ def load_img_info(files):
     img_file, gt_file = files
     # read imgs with ignoring orientations
     img = mmcv.imread(img_file, 'unchanged')
-    # read imgs with orientations as dataloader does when training and testing
-    img_color = mmcv.imread(img_file, 'color')
-    # make sure imgs have no orientation info, or annotation gt is wrong.
-    assert img.shape[0:2] == img_color.shape[0:2]
 
     split_name = osp.basename(osp.dirname(img_file))
     img_info = dict(


### PR DESCRIPTION
# Motivation
In some OCR datasets, including `ctw1500` and `icdar2017`, there are some images containing orientation info in  EXIF data. The default OpenCV backend used in MMCV would read them and apply the rotation on the images. However, their associated annotations are made on the raw pixels, and such inconsistency leads to wrong examples during training.

In previous versions, we chose to save these images in`.png` format and drop the info in the preprocessing step. MMCV 1.3.8 starts to support `color_ignore_orientation` mode that ignores EXIF info when loading images. (https://github.com/open-mmlab/mmcv/pull/1091) This feature helps remove the extra step that modifies the original dataset in our preprocessing scripts, while it ensures the correctness of the annotations. 

Users are recommended to use `LoadOCRImageFromFile` instead of `LoadImageFromFile` in their pipelines.

# BC Breaking
MMCV < 1.3.8 is not supported.

**Note: this PR is intended to be merged together with the release of MMOCR 0.2.1.**