### PR TITLE
Remove deprecated "pretrained" parameter in kie_test_imgs

### DIFF
--- a/tools/kie_test_imgs.py
+++ b/tools/kie_test_imgs.py
@@ -97,7 +97,6 @@ def main():
     # set cudnn_benchmark
     if cfg.get('cudnn_benchmark', False):
         torch.backends.cudnn.benchmark = True
-    cfg.model.pretrained = None
 
     distributed = False
 


### PR DESCRIPTION
The "pretrained" parameter in SDMG-R is removed started from MMOCR 0.2.1. 