### PR TITLE
[Fix] upgrade version requirement of mmdet to 2.14.0 to avoid known bugs

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -15,7 +15,7 @@ RUN apt-get update && apt-get install -y git ninja-build libglib2.0-0 libsm6 lib
 RUN conda clean --all
 RUN pip install mmcv-full -f https://download.openmmlab.com/mmcv/dist/cu101/torch1.6.0/index.html
 
-RUN pip install mmdet==2.13.0
+RUN pip install mmdet==2.14.0
 
 RUN git clone https://github.com/open-mmlab/mmocr.git /mmocr
 WORKDIR /mmocr

--- a/docs/install.md
+++ b/docs/install.md
@@ -10,7 +10,7 @@
 - NCCL 2
 - GCC 5.4.0 or higher
 - [MMCV](https://mmcv.readthedocs.io/en/latest/#installation) >= 1.3.8
-- [MMDetection](https://mmdetection.readthedocs.io/en/latest/#installation) >= 2.13.0
+- [MMDetection](https://mmdetection.readthedocs.io/en/latest/#installation) >= 2.14.0
 
 We have tested the following versions of OS and softwares:
 
@@ -18,7 +18,7 @@ We have tested the following versions of OS and softwares:
 - CUDA: 10.1
 - GCC(G++): 5.4.0
 - MMCV 1.3.8
-- MMDetection 2.13.0
+- MMDetection 2.14.0
 - PyTorch 1.6.0
 - torchvision 0.7.0
 

--- a/docs_zh_CN/install.md
+++ b/docs_zh_CN/install.md
@@ -10,7 +10,7 @@
 - NCCL 2
 - GCC 5.4.0 or higher
 - [MMCV](https://mmcv.readthedocs.io/en/latest/#installation) >= 1.3.8
-- [MMDetection](https://mmdetection.readthedocs.io/en/latest/#installation) >= 2.13.0
+- [MMDetection](https://mmdetection.readthedocs.io/en/latest/#installation) >= 2.14.0
 
 We have tested the following versions of OS and softwares:
 
@@ -18,7 +18,7 @@ We have tested the following versions of OS and softwares:
 - CUDA: 10.1
 - GCC(G++): 5.4.0
 - MMCV 1.3.8
-- MMDetection 2.13.0
+- MMDetection 2.14.0
 - PyTorch 1.6.0
 - torchvision 0.7.0
 

--- a/mmocr/__init__.py
+++ b/mmocr/__init__.py
@@ -26,7 +26,7 @@ assert (mmcv_version >= digit_version(mmcv_minimum_version)
     f'Please use MMCV >= {mmcv_minimum_version}, ' \
     f'<= {mmcv_maximum_version} instead.'
 
-mmdet_minimum_version = '2.13.0'
+mmdet_minimum_version = '2.14.0'
 mmdet_maximum_version = '2.20.0'
 mmdet_version = digit_version(mmdet.__version__)
 


### PR DESCRIPTION
In mmdet 2.13.0, the `__init__()` function of `SingleStageDetector` always assign a value to the `pretrained` variable of the backbone, which could cause an error if the backbone does not accept `pretrained` in its initializer. (https://github.com/open-mmlab/mmdetection/pull/5363). It was fixed in `2.14.0`.

We upgrade the dependency requirement to avoid potential errors.