### PR TITLE
Add output option to det_recog_show_result method

### DIFF
--- a/docs/demo.md
+++ b/docs/demo.md
@@ -80,7 +80,7 @@ from mmocr.utils.ocr import MMOCR
 ocr = MMOCR()
 
 # Inference
-results = ocr.readtext('https://raw.githubusercontent.com/open-mmlab/mmocr/main/demo/resources/demo_text_ocr.jpg', print_result=True, imshow=True)
+results = ocr.readtext('demo/demo_text_ocr.jpg', print_result=True, imshow=True)
 ```
 ---
 

--- a/mmocr/core/visualize.py
+++ b/mmocr/core/visualize.py
@@ -3,7 +3,6 @@ import os
 import shutil
 import urllib
 import warnings
-from pathlib import Path
 
 import cv2
 import mmcv
@@ -599,11 +598,6 @@ def det_recog_show_result(img, end2end_res, out_file=None):
     out_img[:, w:, :] = text_vis_img
 
     if out_file:
-        out_file = Path(out_file)
-        if out_file.is_file():
-            mmcv.imwrite(out_img, str(out_file))
-        else:
-            raise AssertionError(
-                'Output file must be an image file path (str)')
+        mmcv.imwrite(out_img, out_file)
 
     return out_img

--- a/mmocr/core/visualize.py
+++ b/mmocr/core/visualize.py
@@ -3,6 +3,7 @@ import os
 import shutil
 import urllib
 import warnings
+from pathlib import Path
 
 import cv2
 import mmcv
@@ -570,12 +571,13 @@ def is_contain_chinese(check_str):
     return False
 
 
-def det_recog_show_result(img, end2end_res):
+def det_recog_show_result(img, end2end_res, out_file=None):
     """Draw `result`(boxes and texts) on `img`.
+
     Args:
         img (str or np.ndarray): The image to be displayed.
         end2end_res (dict): Text detect and recognize results.
-
+        out_file (str): Image path where the visualized image should be saved.
     Return:
         out_img (np.ndarray): Visualized image.
     """
@@ -595,5 +597,13 @@ def det_recog_show_result(img, end2end_res):
     out_img = np.ones((h, w * 2, 3), dtype=np.uint8)
     out_img[:, :w, :] = box_vis_img
     out_img[:, w:, :] = text_vis_img
+
+    if out_file:
+        out_file = Path(out_file)
+        if out_file.is_file():
+            mmcv.imwrite(out_img, str(out_file))
+        else:
+            raise AssertionError(
+                'Output file must be an image file path (str)')
 
     return out_img


### PR DESCRIPTION
- Added the optional argument `out_file` to specify output path to save the visualized image in the `det_recog_show_result` method
- Fixed wrong url in demo.md