### PR TITLE
[Docs] Fix API reference & version, support exporting pdf & epub

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,5 +1,7 @@
 version: 2
 
+format: all
+
 python:
     version: 3.7
     install:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,6 +1,6 @@
 version: 2
 
-format: all
+formats: all
 
 python:
     version: 3.7

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -23,7 +23,7 @@ copyright = '2020-2030, OpenMMLab'
 author = 'OpenMMLab'
 
 # The full version, including alpha/beta/rc tags
-release = '0.1.0'
+release = '0.2.1'
 
 # -- General configuration ---------------------------------------------------
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -23,7 +23,11 @@ copyright = '2020-2030, OpenMMLab'
 author = 'OpenMMLab'
 
 # The full version, including alpha/beta/rc tags
-release = '0.2.1'
+version_file = '../mmocr/version.py'
+with open(version_file, 'r') as f:
+    exec(compile(f.read(), version_file, 'exec'))
+__version__ = locals()['__version__']
+release = __version__
 
 # -- General configuration ---------------------------------------------------
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -38,29 +38,7 @@ extensions = [
     'sphinx_markdown_tables',
 ]
 
-autodoc_mock_imports = [
-    'torch',
-    'torchvision',
-    'mmcv',
-    'mmocr.version',
-    'mmdet',
-    'imgaug',
-    'kwarray',
-    'lmdb',
-    'matplotlib',
-    'Polygon',
-    'cv2',
-    'numpy',
-    'pyclipper',
-    'pycocotools',
-    'pytest',
-    'rapidfuzz',
-    'scipy',
-    'shapely',
-    'skimage',
-    'titlecase',
-    'PIL',
-]
+autodoc_mock_imports = ['mmcv._ext']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/docs_zh_CN/conf.py
+++ b/docs_zh_CN/conf.py
@@ -23,7 +23,7 @@ copyright = '2020-2030, OpenMMLab'
 author = 'OpenMMLab'
 
 # The full version, including alpha/beta/rc tags
-release = '0.1.0'
+release = '0.2.1'
 
 # -- General configuration ---------------------------------------------------
 

--- a/docs_zh_CN/conf.py
+++ b/docs_zh_CN/conf.py
@@ -23,7 +23,11 @@ copyright = '2020-2030, OpenMMLab'
 author = 'OpenMMLab'
 
 # The full version, including alpha/beta/rc tags
-release = '0.2.1'
+version_file = '../mmocr/version.py'
+with open(version_file, 'r') as f:
+    exec(compile(f.read(), version_file, 'exec'))
+__version__ = locals()['__version__']
+release = __version__
 
 # -- General configuration ---------------------------------------------------
 

--- a/docs_zh_CN/conf.py
+++ b/docs_zh_CN/conf.py
@@ -38,29 +38,7 @@ extensions = [
     'sphinx_markdown_tables',
 ]
 
-autodoc_mock_imports = [
-    'torch',
-    'torchvision',
-    'mmcv',
-    'mmocr.version',
-    'mmdet',
-    'imgaug',
-    'kwarray',
-    'lmdb',
-    'matplotlib',
-    'Polygon',
-    'cv2',
-    'numpy',
-    'pyclipper',
-    'pycocotools',
-    'pytest',
-    'rapidfuzz',
-    'scipy',
-    'shapely',
-    'skimage',
-    'titlecase',
-    'PIL',
-]
+autodoc_mock_imports = ['mmcv._ext']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/requirements/readthedocs.txt
+++ b/requirements/readthedocs.txt
@@ -4,6 +4,7 @@ lanms-proper
 lmdb
 matplotlib
 mmcv
+mmdet
 Polygon3
 pyclipper
 rapidfuzz


### PR DESCRIPTION
Since the introduction of dependency version checking in `__init__`, the old readthedocs config is no longer valid as it mocks MMCV and MMDetection and hides the version information in these packages. The assertion error blocks `autodoc` from importing modules and generate docs for APIs.

`autodoc_mock_imports` also unnecessarily mocked too many modules and this PR removes them.

Also modified code so that the version of the docs can be in sync with MMOCR.