### PR TITLE
Fix #416: Fix undesired assignment to "pretrained" in test.py

### DIFF
--- a/mmocr/utils/ocr.py
+++ b/mmocr/utils/ocr.py
@@ -275,8 +275,7 @@ class MMOCR:
             },
             'RobustScanner': {
                 'config': 'robust_scanner/robustscanner_r31_academic.py',
-                'ckpt':
-                'robustscanner/robustscanner_r31_academic-5f05874f.pth'
+                'ckpt': 'robustscanner/robustscanner_r31_academic-5f05874f.pth'
             },
             'SEG': {
                 'config': 'seg/seg_r31_1by16_fpnocr_academic.py',

--- a/tools/test.py
+++ b/tools/test.py
@@ -127,7 +127,8 @@ def main():
     # set cudnn_benchmark
     if cfg.get('cudnn_benchmark', False):
         torch.backends.cudnn.benchmark = True
-    cfg.model.pretrained = None
+    if cfg.model.get('pretrained'):
+        cfg.model.pretrained = None
     if cfg.model.get('neck'):
         if isinstance(cfg.model.neck, list):
             for neck_cfg in cfg.model.neck:


### PR DESCRIPTION
Some models no longer accept `pretrained` parameter in their constructors and use `init_cfg` to initialize themselves instead. But `test.py` still passes `None` to `pretrained` whichever the model is being tested. So I added a simple check to skip this step. 

Also fixed a linting problem.