### PR TITLE
[Enhancement] Use bounding box around polygon instead of within polygon

### DIFF
--- a/mmocr/datasets/kie_dataset.py
+++ b/mmocr/datasets/kie_dataset.py
@@ -222,6 +222,7 @@ class KIEDataset(BaseDataset):
              boxes[:, 0::2].max(axis=1, keepdims=True),
              boxes[:, 1::2].max(axis=1, keepdims=True)],
             axis=1).astype(np.float32)
+        # yapf: enable
         x1, y1 = bboxes[:, 0:1], bboxes[:, 1:2]
         x2, y2 = bboxes[:, 2:3], bboxes[:, 3:4]
         w, h = np.maximum(x2 - x1 + 1, 1), np.maximum(y2 - y1 + 1, 1)

--- a/mmocr/datasets/kie_dataset.py
+++ b/mmocr/datasets/kie_dataset.py
@@ -215,12 +215,13 @@ class KIEDataset(BaseDataset):
     def compute_relation(self, boxes):
         """Compute relation between every two boxes."""
         # Get minimal axis-aligned bounding boxes for each of the boxes
+        # yapf: disable
         bboxes = np.concatenate(
             [boxes[:, 0::2].min(axis=1, keepdims=True),
              boxes[:, 1::2].min(axis=1, keepdims=True),
              boxes[:, 0::2].max(axis=1, keepdims=True),
              boxes[:, 1::2].max(axis=1, keepdims=True)],
-             axis=1).astype(np.float32)
+            axis=1).astype(np.float32)
         x1, y1 = bboxes[:, 0:1], bboxes[:, 1:2]
         x2, y2 = bboxes[:, 2:3], bboxes[:, 3:4]
         w, h = np.maximum(x2 - x1 + 1, 1), np.maximum(y2 - y1 + 1, 1)

--- a/mmocr/datasets/kie_dataset.py
+++ b/mmocr/datasets/kie_dataset.py
@@ -214,13 +214,19 @@ class KIEDataset(BaseDataset):
 
     def compute_relation(self, boxes):
         """Compute relation between every two boxes."""
-        x1, y1 = boxes[:, 0:1], boxes[:, 1:2]
-        x2, y2 = boxes[:, 4:5], boxes[:, 5:6]
+        # Get minimal axis-aligned bounding boxes for each of the boxes
+        bboxes = np.concatenate(
+            [boxes[:, 0::2].min(axis=1, keepdims=True),
+             boxes[:, 1::2].min(axis=1, keepdims=True),
+             boxes[:, 0::2].max(axis=1, keepdims=True),
+             boxes[:, 1::2].max(axis=1, keepdims=True)],
+             axis=1).astype(np.float32)
+        x1, y1 = bboxes[:, 0:1], bboxes[:, 1:2]
+        x2, y2 = bboxes[:, 2:3], bboxes[:, 3:4]
         w, h = np.maximum(x2 - x1 + 1, 1), np.maximum(y2 - y1 + 1, 1)
         dx = (x1.T - x1) / self.norm
         dy = (y1.T - y1) / self.norm
         xhh, xwh = h.T / h, w.T / h
         whs = w / h + np.zeros_like(xhh)
         relation = np.stack([dx, dy, whs, xhh, xwh], -1).astype(np.float32)
-        bboxes = np.concatenate([x1, y1, x2, y2], -1).astype(np.float32)
         return relation, bboxes


### PR DESCRIPTION
Address https://github.com/open-mmlab/mmocr/issues/463

Here are the results from training a unet model with and without the modification. (training logs and epoch 60 checkpoints available on request)

Version|Best F1 score|F1 score @ 60 epochs
-|-|-
Old|0.894 @ epoch 43|0.884
New|0.895 @ epoch 44|0.888

The Wildreceipt dataset seems to have mostly axis-aligned polygons so we wouldn't have expected a noticeable different.