### PR TITLE
[Fix] Modify algorithm "sar" weights path in metafile

### DIFF
--- a/configs/textrecog/sar/metafile.yml
+++ b/configs/textrecog/sar/metafile.yml
@@ -55,7 +55,7 @@ Models:
         Dataset: CT80
         Metrics:
           word_acc: 88.9
-    Weights: https://download.openmmlab.com/mmocr/textrecog/crnn/crnn_academic-a723a1c5.pth
+    Weights: https://download.openmmlab.com/mmocr/textrecog/sar/sar_r31_parallel_decoder_academic-dba3a4a3.pth
 
   - Name: sar_r31_sequential_decoder_academic
     In Collection: SAR


### PR DESCRIPTION
Original model `sar_r31_parallel_decoder_academic` weights path in sar/metafile.yml belongs to crnn which should be modified.