### PR TITLE
[Enhancement] Use shape from loaded image

### DIFF
--- a/mmocr/datasets/pipelines/loading.py
+++ b/mmocr/datasets/pipelines/loading.py
@@ -42,6 +42,10 @@ class LoadTextAnnotations(LoadAnnotations):
     def _load_masks(self, results):
         ann_info = results['ann_info']
         h, w = results['img_info']['height'], results['img_info']['width']
+        if results.get('ori_shape', None):
+            h, w = results['ori_shape'][:2]
+            results['img_info']['height'] = h
+            results['img_info']['width'] = w
         gt_masks = ann_info['masks']
         if self.poly2mask:
             gt_masks = BitmapMasks(


### PR DESCRIPTION
Use the shape of the loaded image so that fake `width` and `height` can be given in the annotation file.