### PR TITLE
[Enhancement] Support muitiple pipelines for different datasets

### DIFF
--- a/docs/en/dataset_types.md
+++ b/docs/en/dataset_types.md
@@ -29,6 +29,23 @@ data = dict(
         pipeline=train_pipeline))
 ```
 
+Also, it support apply different `pipeline` to different `datasets`,
+
+```python
+train_list1 = [train1, train2]
+train_list2 = [train3, train4]
+
+data = dict(
+    ...
+    train=dict(
+        type='UniformConcatDataset',
+        datasets=[train_list1, train_list2],
+        pipeline=[train_pipeline1, train_pipeline2]))
+```
+
+Here, `train_pipeline1` will be applied to `train1` and `train2`, and
+`train_pipeline2` will be applied to `train3` and `train4`.
+
 ## Text Detection Task
 
 ### TextDetDataset

--- a/mmocr/apis/__init__.py
+++ b/mmocr/apis/__init__.py
@@ -1,7 +1,9 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 from .inference import init_detector, model_inference
 from .train import init_random_seed, train_detector
+from .utils import disable_text_recog_aug_test, replace_image_to_tensor
 
 __all__ = [
-    'model_inference', 'train_detector', 'init_detector', 'init_random_seed'
+    'model_inference', 'train_detector', 'init_detector', 'init_random_seed',
+    'replace_image_to_tensor', 'disable_text_recog_aug_test'
 ]

--- a/mmocr/apis/inference.py
+++ b/mmocr/apis/inference.py
@@ -92,7 +92,7 @@ def model_inference(model,
     cfg = model.cfg
 
     if batch_mode:
-        disable_text_recog_aug_test(cfg, set_types=['test'])
+        cfg = disable_text_recog_aug_test(cfg, set_types=['test'])
 
     device = next(model.parameters()).device  # model device
 

--- a/mmocr/apis/inference.py
+++ b/mmocr/apis/inference.py
@@ -96,7 +96,7 @@ def model_inference(model,
 
     device = next(model.parameters()).device  # model device
 
-    if cfg.data.test.pipeline is None:
+    if cfg.data.test.get('pipeline', None) is None:
         cfg.data.test.pipeline = cfg.data.test.datasets[0].pipeline
     if is_2dlist(cfg.data.test.pipeline):
         cfg.data.test.pipeline = cfg.data.test.pipeline[0]

--- a/mmocr/apis/inference.py
+++ b/mmocr/apis/inference.py
@@ -12,6 +12,8 @@ from mmdet.datasets import replace_ImageToTensor
 from mmdet.datasets.pipelines import Compose
 
 from mmocr.models import build_detector
+from mmocr.utils import is_2dlist
+from .utils import disable_text_recog_aug_test
 
 
 def init_detector(config, checkpoint=None, device='cuda:0', cfg_options=None):
@@ -54,54 +56,6 @@ def init_detector(config, checkpoint=None, device='cuda:0', cfg_options=None):
     return model
 
 
-def disable_text_recog_aug_test(cfg, set_types=None):
-    """Remove aug_test from test pipeline of text recognition.
-    Args:
-        cfg (mmcv.Config): Input config.
-        set_types (list[str]): Type of dataset source. Should be
-            None or sublist of ['test', 'val']
-
-    Returns:
-        cfg (mmcv.Config): Output config removing
-            `MultiRotateAugOCR` in test pipeline.
-    """
-    assert set_types is None or isinstance(set_types, list)
-    if set_types is None:
-        set_types = ['val', 'test']
-    warnings.simplefilter('once')
-    warning_msg = 'Remove "MultiRotateAugOCR" to support batch ' + \
-        'inference since samples_per_gpu > 1.'
-    for set_type in set_types:
-        dataset_type = cfg.data[set_type].type
-        if dataset_type in ['OCRDataset', 'OCRSegDataset']:
-            if cfg.data[set_type].pipeline[1].type == 'MultiRotateAugOCR':
-                warnings.warn(warning_msg)
-                cfg.data[set_type].pipeline = [
-                    cfg.data[set_type].pipeline[0],
-                    *cfg.data[set_type].pipeline[1].transforms
-                ]
-        elif dataset_type in ['ConcatDataset', 'UniformConcatDataset']:
-            if dataset_type == 'UniformConcatDataset':
-                uniform_pipeline = cfg.data[set_type].pipeline
-                if uniform_pipeline is not None:
-                    if uniform_pipeline[1].type == 'MultiRotateAugOCR':
-                        warnings.warn(warning_msg)
-                        cfg.data[set_type].pipeline = [
-                            uniform_pipeline[0],
-                            *uniform_pipeline[1].transforms
-                        ]
-            for dataset in cfg.data[set_type].datasets:
-                if dataset.pipeline is not None:
-                    if dataset.pipeline[1].type == 'MultiRotateAugOCR':
-                        warnings.warn(warning_msg)
-                        dataset.pipeline = [
-                            dataset.pipeline[0],
-                            *dataset.pipeline[1].transforms
-                        ]
-
-    return cfg
-
-
 def model_inference(model,
                     imgs,
                     ann=None,
@@ -138,9 +92,14 @@ def model_inference(model,
     cfg = model.cfg
 
     if batch_mode:
-        cfg = disable_text_recog_aug_test(cfg, set_types=['test'])
+        disable_text_recog_aug_test(cfg, set_types=['test'])
 
     device = next(model.parameters()).device  # model device
+
+    if cfg.data.test.pipeline is None:
+        cfg.data.test.pipeline = cfg.data.test.datasets[0].pipeline
+    if is_2dlist(cfg.data.test.pipeline):
+        cfg.data.test.pipeline = cfg.data.test.pipeline[0]
 
     if is_ndarray:
         cfg = cfg.copy()

--- a/mmocr/apis/train.py
+++ b/mmocr/apis/train.py
@@ -9,10 +9,10 @@ from mmcv.runner import (DistSamplerSeedHook, EpochBasedRunner,
                          Fp16OptimizerHook, OptimizerHook, build_optimizer,
                          build_runner, get_dist_info)
 from mmdet.core import DistEvalHook, EvalHook
-from mmdet.datasets import (build_dataloader, build_dataset,
-                            replace_ImageToTensor)
+from mmdet.datasets import build_dataloader, build_dataset
 
-from mmocr.apis.inference import disable_text_recog_aug_test
+from mmocr.apis.utils import (disable_text_recog_aug_test,
+                              replace_image_to_tensor)
 from mmocr.utils import get_root_logger
 
 
@@ -125,11 +125,8 @@ def train_detector(model,
         if val_samples_per_gpu > 1:
             # Support batch_size > 1 in test for text recognition
             # by disable MultiRotateAugOCR since it is useless for most case
-            cfg = disable_text_recog_aug_test(cfg)
-            if cfg.data.val.get('pipeline', None) is not None:
-                # Replace 'ImageToTensor' to 'DefaultFormatBundle'
-                cfg.data.val.pipeline = replace_ImageToTensor(
-                    cfg.data.val.pipeline)
+            disable_text_recog_aug_test(cfg)
+            replace_image_to_tensor(cfg)
 
         val_dataset = build_dataset(cfg.data.val, dict(test_mode=True))
 

--- a/mmocr/apis/train.py
+++ b/mmocr/apis/train.py
@@ -125,8 +125,8 @@ def train_detector(model,
         if val_samples_per_gpu > 1:
             # Support batch_size > 1 in test for text recognition
             # by disable MultiRotateAugOCR since it is useless for most case
-            disable_text_recog_aug_test(cfg)
-            replace_image_to_tensor(cfg)
+            cfg = disable_text_recog_aug_test(cfg)
+            cfg = replace_image_to_tensor(cfg)
 
         val_dataset = build_dataset(cfg.data.val, dict(test_mode=True))
 

--- a/mmocr/apis/utils.py
+++ b/mmocr/apis/utils.py
@@ -1,4 +1,5 @@
 # Copyright (c) OpenMMLab. All rights reserved.
+import copy
 import warnings
 
 from mmdet.datasets import replace_ImageToTensor
@@ -19,6 +20,8 @@ def replace_image_to_tensor(cfg, set_types=None):
     assert set_types is None or isinstance(set_types, list)
     if set_types is None:
         set_types = ['val', 'test']
+
+    cfg = copy.deepcopy(cfg)
     for set_type in set_types:
         assert set_type in ['val', 'test']
         uniform_pipeline = cfg.data[set_type].get('pipeline', None)
@@ -34,6 +37,8 @@ def replace_image_to_tensor(cfg, set_types=None):
                     update_pipeline(each_dataset)
             else:
                 update_pipeline(dataset)
+
+    return cfg
 
 
 def update_pipeline_recog(cfg, idx=None):
@@ -61,6 +66,8 @@ def disable_text_recog_aug_test(cfg, set_types=None):
     assert set_types is None or isinstance(set_types, list)
     if set_types is None:
         set_types = ['val', 'test']
+
+    cfg = copy.deepcopy(cfg)
     warnings.simplefilter('once')
     for set_type in set_types:
         assert set_type in ['val', 'test']
@@ -84,3 +91,5 @@ def disable_text_recog_aug_test(cfg, set_types=None):
                     update_pipeline_recog(each_dataset)
             else:
                 update_pipeline_recog(dataset)
+
+    return cfg

--- a/mmocr/apis/utils.py
+++ b/mmocr/apis/utils.py
@@ -1,0 +1,84 @@
+import warnings
+
+from mmdet.datasets import replace_ImageToTensor
+
+from mmocr.utils import is_2dlist
+
+
+def update_pipeline(cfg, idx=None):
+    if idx is None:
+        if cfg.pipeline is not None:
+            cfg.pipeline = replace_ImageToTensor(cfg.pipeline)
+    else:
+        cfg.pipeline[idx] = replace_ImageToTensor(cfg.pipeline[idx])
+
+
+def replace_image_to_tensor(cfg, set_types=None):
+    """Replace 'ImageToTensor' to 'DefaultFormatBundle'."""
+    assert set_types is None or isinstance(set_types, list)
+    if set_types is None:
+        set_types = ['val', 'test']
+    for set_type in set_types:
+        assert set_type in ['val', 'test']
+        uniform_pipeline = cfg.data[set_type].get('pipeline', None)
+        if uniform_pipeline is not None:
+            if is_2dlist(uniform_pipeline):
+                for idx, _ in enumerate(uniform_pipeline):
+                    update_pipeline(cfg.data[set_type], idx)
+            else:
+                update_pipeline(cfg.data[set_type])
+
+        dataset_type = cfg.data[set_type].type
+        if dataset_type in ['ConcatDataset', 'UniformConcatDataset']:
+            for dataset in cfg.data[set_type].datasets:
+                if isinstance(dataset, list):
+                    for each_dataset in dataset:
+                        update_pipeline(each_dataset)
+                else:
+                    update_pipeline(dataset)
+
+
+def remove_aug_test(cfg, idx=None):
+    warning_msg = 'Remove "MultiRotateAugOCR" to support batch ' + \
+        'inference since samples_per_gpu > 1.'
+    if idx is None:
+        if cfg.get('pipeline',
+                   None) and cfg.pipeline[1].type == 'MultiRotateAugOCR':
+            warnings.warn(warning_msg)
+            cfg.pipeline = [cfg.pipeline[0], *cfg.pipeline[1].transforms]
+    else:
+        if cfg[idx][1].type == 'MultiRotateAugOCR':
+            warnings.warn(warning_msg)
+            cfg[idx] = [cfg[idx][0], *cfg[idx][1].transforms]
+
+
+def disable_text_recog_aug_test(cfg, set_types=None):
+    """Remove aug_test from test pipeline for text recognition.
+
+    Args:
+        cfg (mmcv.Config): Input config.
+        set_types (list[str]): Type of dataset source. Should be
+            None or sublist of ['test', 'val'].
+    """
+    assert set_types is None or isinstance(set_types, list)
+    if set_types is None:
+        set_types = ['val', 'test']
+    warnings.simplefilter('once')
+    for set_type in set_types:
+        dataset_type = cfg.data[set_type].type
+        if dataset_type in ['OCRDataset', 'OCRSegDataset']:
+            remove_aug_test(cfg.data[set_type])
+        elif dataset_type in ['ConcatDataset', 'UniformConcatDataset']:
+            uniform_pipeline = cfg.data[set_type].get('pipeline', None)
+            if uniform_pipeline is not None:
+                if is_2dlist(uniform_pipeline):
+                    for idx, _ in enumerate(uniform_pipeline):
+                        remove_aug_test(cfg.data[set_type].pipeline, idx)
+                else:
+                    remove_aug_test(cfg.data[set_type])
+            for dataset in cfg.data[set_type].datasets:
+                if isinstance(dataset, list):
+                    for each_dataset in dataset:
+                        remove_aug_test(each_dataset)
+                else:
+                    remove_aug_test(dataset)

--- a/mmocr/apis/utils.py
+++ b/mmocr/apis/utils.py
@@ -1,3 +1,4 @@
+# Copyright (c) OpenMMLab. All rights reserved.
 import warnings
 
 from mmdet.datasets import replace_ImageToTensor

--- a/mmocr/datasets/uniform_concat_dataset.py
+++ b/mmocr/datasets/uniform_concat_dataset.py
@@ -35,9 +35,9 @@ class UniformConcatDataset(ConcatDataset):
                  **kwargs):
         new_datasets = []
         if pipeline is not None:
-            assert len(
-                pipeline
-            ) > 0, 'pipeline must be list[dict] or list[list[dict]].'
+            assert isinstance(
+                pipeline,
+                list), 'pipeline must be list[dict] or list[list[dict]].'
             if is_type_list(pipeline, dict):
                 self._apply_pipeline(datasets, pipeline, force_apply)
                 new_datasets = datasets

--- a/mmocr/datasets/uniform_concat_dataset.py
+++ b/mmocr/datasets/uniform_concat_dataset.py
@@ -3,27 +3,42 @@ import copy
 
 from mmdet.datasets import DATASETS, ConcatDataset, build_dataset
 
+from mmocr.utils import is_2dlist
+
 
 @DATASETS.register_module()
 class UniformConcatDataset(ConcatDataset):
-    """A wrapper of concatenated dataset.
-
-    Same as :obj:`torch.utils.data.dataset.ConcatDataset`, but
-    concat the group flag for image aspect ratio.
+    """A wrapper of ConcatDataset which support dataset pipeline assignment and
+    replacement.
 
     Args:
         datasets (list[:obj:`Dataset`]): A list of datasets.
         separate_eval (bool): Whether to evaluate the results
             separately if it is used as validation dataset.
             Defaults to True.
+        pipeline (None | list[dict] | list[list[dict]]): If ``None``,
+            each dataset in datasets use its own pipeline;
+            If ``list[dict]``, it will be assigned to the dataset whose
+            pipeline is None in datasets;
+            If ``list[list[dict]]``, pipeline of dataset which is None
+            in datasets will be replaced by the corresponding pipeline
+            in the list.
     """
 
     def __init__(self, datasets, separate_eval=True, pipeline=None, **kwargs):
         from_cfg = all(isinstance(x, dict) for x in datasets)
         if pipeline is not None:
             assert from_cfg, 'datasets should be config dicts'
-            for dataset in datasets:
-                if dataset['pipeline'] is None:
-                    dataset['pipeline'] = copy.deepcopy(pipeline)
+            if is_2dlist(pipeline):
+                assert len(datasets) == len(pipeline)
+                for dataset, tmp_pipeline in zip(datasets, pipeline):
+                    assert all(isinstance(x, dict) for x in tmp_pipeline)
+                    if dataset['pipeline'] is None:
+                        dataset['pipeline'] = copy.deepcopy(tmp_pipeline)
+            elif isinstance(pipeline, list):
+                assert all(isinstance(x, dict) for x in pipeline)
+                for dataset in datasets:
+                    if dataset['pipeline'] is None:
+                        dataset['pipeline'] = copy.deepcopy(pipeline)
         datasets = [build_dataset(c, kwargs) for c in datasets]
         super().__init__(datasets, separate_eval)

--- a/mmocr/datasets/uniform_concat_dataset.py
+++ b/mmocr/datasets/uniform_concat_dataset.py
@@ -12,7 +12,7 @@ class UniformConcatDataset(ConcatDataset):
     replacement.
 
     Args:
-        datasets (list[:obj:`Dataset`]): A list of datasets.
+        datasets (list[dict] | list[list[dict]]): A list of datasets cfgs.
         separate_eval (bool): Whether to evaluate the results
             separately if it is used as validation dataset.
             Defaults to True.
@@ -23,22 +23,45 @@ class UniformConcatDataset(ConcatDataset):
             If ``list[list[dict]]``, pipeline of dataset which is None
             in datasets will be replaced by the corresponding pipeline
             in the list.
+        force_apply (bool): If True, apply pipeline above to each dataset
+            even if it have its own pipeline. Default: False.
     """
 
-    def __init__(self, datasets, separate_eval=True, pipeline=None, **kwargs):
-        from_cfg = all(isinstance(x, dict) for x in datasets)
+    def __init__(self,
+                 datasets,
+                 separate_eval=True,
+                 pipeline=None,
+                 force_apply=False,
+                 **kwargs):
+        new_datasets = []
         if pipeline is not None:
-            assert from_cfg, 'datasets should be config dicts'
+            assert len(
+                pipeline
+            ) > 0, 'pipeline must be list[dict] or list[list[dict]],'
             if is_2dlist(pipeline):
+                assert is_2dlist(datasets)
                 assert len(datasets) == len(pipeline)
-                for dataset, tmp_pipeline in zip(datasets, pipeline):
-                    assert all(isinstance(x, dict) for x in tmp_pipeline)
-                    if dataset['pipeline'] is None:
-                        dataset['pipeline'] = copy.deepcopy(tmp_pipeline)
+                for sub_datasets, tmp_pipeline in zip(datasets, pipeline):
+                    self._apply_pipeline(sub_datasets, tmp_pipeline,
+                                         force_apply)
+                    new_datasets.extend(sub_datasets)
             elif isinstance(pipeline, list):
-                assert all(isinstance(x, dict) for x in pipeline)
-                for dataset in datasets:
-                    if dataset['pipeline'] is None:
-                        dataset['pipeline'] = copy.deepcopy(pipeline)
-        datasets = [build_dataset(c, kwargs) for c in datasets]
+                self._apply_pipeline(datasets, pipeline, force_apply)
+                new_datasets = datasets
+        else:
+            if is_2dlist(datasets):
+                for sub_datasets in datasets:
+                    new_datasets.extend(sub_datasets)
+            else:
+                new_datasets = datasets
+        datasets = [build_dataset(c, kwargs) for c in new_datasets]
         super().__init__(datasets, separate_eval)
+
+    @staticmethod
+    def _apply_pipeline(datasets, pipeline, force_apply=False):
+        from_cfg = all(isinstance(x, dict) for x in datasets)
+        assert from_cfg, 'datasets should be config dicts'
+        assert all(isinstance(x, dict) for x in pipeline)
+        for dataset in datasets:
+            if dataset['pipeline'] is None or force_apply:
+                dataset['pipeline'] = copy.deepcopy(pipeline)

--- a/mmocr/datasets/uniform_concat_dataset.py
+++ b/mmocr/datasets/uniform_concat_dataset.py
@@ -3,7 +3,7 @@ import copy
 
 from mmdet.datasets import DATASETS, ConcatDataset, build_dataset
 
-from mmocr.utils import is_2dlist
+from mmocr.utils import is_2dlist, is_type_list
 
 
 @DATASETS.register_module()
@@ -37,17 +37,17 @@ class UniformConcatDataset(ConcatDataset):
         if pipeline is not None:
             assert len(
                 pipeline
-            ) > 0, 'pipeline must be list[dict] or list[list[dict]],'
-            if is_2dlist(pipeline):
+            ) > 0, 'pipeline must be list[dict] or list[list[dict]].'
+            if is_type_list(pipeline, dict):
+                self._apply_pipeline(datasets, pipeline, force_apply)
+                new_datasets = datasets
+            elif is_2dlist(pipeline):
                 assert is_2dlist(datasets)
                 assert len(datasets) == len(pipeline)
                 for sub_datasets, tmp_pipeline in zip(datasets, pipeline):
                     self._apply_pipeline(sub_datasets, tmp_pipeline,
                                          force_apply)
                     new_datasets.extend(sub_datasets)
-            elif isinstance(pipeline, list):
-                self._apply_pipeline(datasets, pipeline, force_apply)
-                new_datasets = datasets
         else:
             if is_2dlist(datasets):
                 for sub_datasets in datasets:

--- a/tests/test_apis/test_model_inference.py
+++ b/tests/test_apis/test_model_inference.py
@@ -6,8 +6,8 @@ import pytest
 from mmcv import Config
 from mmcv.image import imread
 
-from mmocr.apis.inference import (disable_text_recog_aug_test, init_detector,
-                                  model_inference)
+from mmocr.apis.inference import init_detector, model_inference
+from mmocr.apis.utils import disable_text_recog_aug_test
 from mmocr.datasets import build_dataset  # noqa: F401
 from mmocr.models import build_detector  # noqa: F401
 from mmocr.utils import revert_sync_batchnorm

--- a/tests/test_apis/test_model_inference.py
+++ b/tests/test_apis/test_model_inference.py
@@ -1,13 +1,10 @@
 # Copyright (c) OpenMMLab. All rights reserved.
-import copy
 import os
 
 import pytest
-from mmcv import Config
 from mmcv.image import imread
 
 from mmocr.apis.inference import init_detector, model_inference
-from mmocr.apis.utils import disable_text_recog_aug_test
 from mmocr.datasets import build_dataset  # noqa: F401
 from mmocr.models import build_detector  # noqa: F401
 from mmocr.utils import revert_sync_batchnorm
@@ -124,26 +121,3 @@ def test_model_batch_inference_empty_detection(cfg_file):
             match='empty imgs provided, please check and try again'):
 
         model_inference(model, empty_detection, batch_mode=True)
-
-
-@pytest.mark.parametrize('cfg_file', [
-    '../configs/textrecog/sar/sar_r31_parallel_decoder_academic.py',
-])
-def test_disable_text_recog_aug_test(cfg_file):
-    tmp_dir = os.path.abspath(os.path.dirname(os.path.dirname(__file__)))
-    config_file = os.path.join(tmp_dir, cfg_file)
-
-    cfg = Config.fromfile(config_file)
-    cfg1 = copy.deepcopy(cfg)
-    test = cfg1.data.test.datasets[0]
-    test.pipeline = cfg1.data.test.pipeline
-    cfg1.data.test = test
-    disable_text_recog_aug_test(cfg1, set_types=['test'])
-
-    cfg2 = copy.deepcopy(cfg)
-    cfg2.data.test.pipeline = None
-    disable_text_recog_aug_test(cfg2, set_types=['test'])
-
-    cfg2 = copy.deepcopy(cfg)
-    cfg2.data.test = Config(dict(type='ConcatDataset', datasets=[test]))
-    disable_text_recog_aug_test(cfg2, set_types=['test'])

--- a/tests/test_apis/test_utils.py
+++ b/tests/test_apis/test_utils.py
@@ -1,0 +1,107 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+import copy
+import os
+
+import pytest
+from mmcv import Config
+
+from mmocr.apis.utils import (disable_text_recog_aug_test,
+                              replace_image_to_tensor)
+
+
+@pytest.mark.parametrize('cfg_file', [
+    '../configs/textrecog/sar/sar_r31_parallel_decoder_academic.py',
+])
+def test_disable_text_recog_aug_test(cfg_file):
+    tmp_dir = os.path.abspath(os.path.dirname(os.path.dirname(__file__)))
+    config_file = os.path.join(tmp_dir, cfg_file)
+
+    cfg = Config.fromfile(config_file)
+    test = cfg.data.test.datasets[0]
+
+    # cfg.data.test.type is 'OCRDataset'
+    cfg1 = copy.deepcopy(cfg)
+    test1 = copy.deepcopy(test)
+    test1.pipeline = cfg1.data.test.pipeline
+    cfg1.data.test = test1
+    cfg1 = disable_text_recog_aug_test(cfg1, set_types=['test'])
+    assert cfg1.data.test.pipeline[1].type != 'MultiRotateAugOCR'
+
+    # cfg.data.test.type is 'UniformConcatDataset'
+    # and cfg.data.test.pipeline is list[dict]
+    cfg2 = copy.deepcopy(cfg)
+    test2 = copy.deepcopy(test)
+    test2.pipeline = cfg2.data.test.pipeline
+    cfg2.data.test.datasets = [test2]
+    cfg2 = disable_text_recog_aug_test(cfg2, set_types=['test'])
+    assert cfg2.data.test.pipeline[1].type != 'MultiRotateAugOCR'
+    assert cfg2.data.test.datasets[0].pipeline[1].type != 'MultiRotateAugOCR'
+
+    # cfg.data.test.type is 'ConcatDataset'
+    cfg3 = copy.deepcopy(cfg)
+    test3 = copy.deepcopy(test)
+    test3.pipeline = cfg3.data.test.pipeline
+    cfg3.data.test = Config(dict(type='ConcatDataset', datasets=[test3]))
+    cfg3 = disable_text_recog_aug_test(cfg3, set_types=['test'])
+    assert cfg3.data.test.datasets[0].pipeline[1].type != 'MultiRotateAugOCR'
+
+    # cfg.data.test.type is 'UniformConcatDataset'
+    # and cfg.data.test.pipeline is list[list[dict]]
+    cfg4 = copy.deepcopy(cfg)
+    test4 = copy.deepcopy(test)
+    test4.pipeline = cfg4.data.test.pipeline
+    cfg4.data.test.datasets = [[test4], [test]]
+    cfg4.data.test.pipeline = [
+        cfg4.data.test.pipeline, cfg4.data.test.pipeline
+    ]
+    cfg4 = disable_text_recog_aug_test(cfg4, set_types=['test'])
+    assert cfg4.data.test.datasets[0][0].pipeline[1].type != \
+        'MultiRotateAugOCR'
+
+    # cfg.data.test.type is 'UniformConcatDataset'
+    # and cfg.data.test.pipeline is None
+    cfg5 = copy.deepcopy(cfg)
+    test5 = copy.deepcopy(test)
+    test5.pipeline = copy.deepcopy(cfg5.data.test.pipeline)
+    cfg5.data.test.datasets = [test5]
+    cfg5.data.test.pipeline = None
+    cfg5 = disable_text_recog_aug_test(cfg5, set_types=['test'])
+    assert cfg5.data.test.datasets[0].pipeline[1].type != 'MultiRotateAugOCR'
+
+
+@pytest.mark.parametrize('cfg_file', [
+    '../configs/textdet/psenet/psenet_r50_fpnf_600e_ctw1500.py',
+])
+def test_replace_image_to_tensor(cfg_file):
+    tmp_dir = os.path.abspath(os.path.dirname(os.path.dirname(__file__)))
+    config_file = os.path.join(tmp_dir, cfg_file)
+
+    cfg = Config.fromfile(config_file)
+    test = cfg.data.test.datasets[0]
+
+    # cfg.data.test.pipeline is list[dict]
+    # and cfg.data.test.datasets is list[dict]
+    cfg1 = copy.deepcopy(cfg)
+    test1 = copy.deepcopy(test)
+    test1.pipeline = copy.deepcopy(cfg.data.test.pipeline)
+    cfg1.data.test.datasets = [test1]
+    cfg1 = replace_image_to_tensor(cfg1, set_types=['test'])
+    assert cfg1.data.test.pipeline[1]['transforms'][3][
+        'type'] == 'DefaultFormatBundle'
+    assert cfg1.data.test.datasets[0].pipeline[1]['transforms'][3][
+        'type'] == 'DefaultFormatBundle'
+
+    # cfg.data.test.pipeline is list[list[dict]]
+    # and cfg.data.test.datasets is list[list[dict]]
+    cfg2 = copy.deepcopy(cfg)
+    test2 = copy.deepcopy(test)
+    test2.pipeline = copy.deepcopy(cfg.data.test.pipeline)
+    cfg2.data.test.datasets = [[test2], [test2]]
+    cfg2.data.test.pipeline = [
+        cfg2.data.test.pipeline, cfg2.data.test.pipeline
+    ]
+    cfg2 = replace_image_to_tensor(cfg2, set_types=['test'])
+    assert cfg2.data.test.pipeline[0][1]['transforms'][3][
+        'type'] == 'DefaultFormatBundle'
+    assert cfg2.data.test.datasets[0][0].pipeline[1]['transforms'][3][
+        'type'] == 'DefaultFormatBundle'

--- a/tests/test_dataset/test_uniform_concat_dataset.py
+++ b/tests/test_dataset/test_uniform_concat_dataset.py
@@ -1,4 +1,6 @@
 # Copyright (c) OpenMMLab. All rights reserved.
+import copy
+
 from mmocr.datasets import UniformConcatDataset
 from mmocr.utils import list_from_file
 
@@ -27,19 +29,32 @@ def test_dataset_warpper():
     train2 = {key: value for key, value in train1.items()}
     train2['pipeline'] = pipeline2
 
-    # test pipeline is 1d list
-    uniform_concat_dataset = UniformConcatDataset(
-        datasets=[train1, train2], pipeline=pipeline1)
+    # pipeline is 1d list
+    copy_train1 = copy.deepcopy(train1)
+    copy_train2 = copy.deepcopy(train2)
+    tmp_dataset = UniformConcatDataset(
+        datasets=[copy_train1, copy_train2],
+        pipeline=pipeline1,
+        force_apply=True)
 
-    assert len(uniform_concat_dataset) == 2 * len(list_from_file(ann_file))
-    assert len(uniform_concat_dataset.datasets[0].pipeline.transforms) != len(
-        uniform_concat_dataset.datasets[1].pipeline.transforms)
+    assert len(tmp_dataset) == 2 * len(list_from_file(ann_file))
+    assert len(tmp_dataset.datasets[0].pipeline.transforms) == len(
+        tmp_dataset.datasets[1].pipeline.transforms)
 
-    # test pipeline is None
-    tmp_dataset = UniformConcatDataset(datasets=[train2], pipeline=None)
+    # pipeline is None
+    copy_train2 = copy.deepcopy(train2)
+    tmp_dataset = UniformConcatDataset(datasets=[copy_train2], pipeline=None)
     assert len(tmp_dataset.datasets[0].pipeline.transforms) == len(pipeline2)
 
-    # test pipeline is 2d list
+    copy_train2 = copy.deepcopy(train2)
     tmp_dataset = UniformConcatDataset(
-        datasets=[train1, train2], pipeline=[pipeline1, pipeline2])
+        datasets=[[copy_train2], [copy_train2]], pipeline=None)
+    assert len(tmp_dataset.datasets[0].pipeline.transforms) == len(pipeline2)
+
+    # pipeline is 2d list
+    copy_train1 = copy.deepcopy(train1)
+    copy_train2 = copy.deepcopy(train2)
+    tmp_dataset = UniformConcatDataset(
+        datasets=[[copy_train1], [copy_train2]],
+        pipeline=[pipeline1, pipeline2])
     assert len(tmp_dataset.datasets[0].pipeline.transforms) == len(pipeline1)

--- a/tests/test_dataset/test_uniform_concat_dataset.py
+++ b/tests/test_dataset/test_uniform_concat_dataset.py
@@ -27,9 +27,19 @@ def test_dataset_warpper():
     train2 = {key: value for key, value in train1.items()}
     train2['pipeline'] = pipeline2
 
+    # test pipeline is 1d list
     uniform_concat_dataset = UniformConcatDataset(
         datasets=[train1, train2], pipeline=pipeline1)
 
     assert len(uniform_concat_dataset) == 2 * len(list_from_file(ann_file))
     assert len(uniform_concat_dataset.datasets[0].pipeline.transforms) != len(
         uniform_concat_dataset.datasets[1].pipeline.transforms)
+
+    # test pipeline is None
+    tmp_dataset = UniformConcatDataset(datasets=[train2], pipeline=None)
+    assert len(tmp_dataset.datasets[0].pipeline.transforms) == len(pipeline2)
+
+    # test pipeline is 2d list
+    tmp_dataset = UniformConcatDataset(
+        datasets=[train1, train2], pipeline=[pipeline1, pipeline2])
+    assert len(tmp_dataset.datasets[0].pipeline.transforms) == len(pipeline1)

--- a/tools/test.py
+++ b/tools/test.py
@@ -227,8 +227,8 @@ def main():
     samples_per_gpu = (cfg.data.get('test_dataloader', {})).get(
         'samples_per_gpu', cfg.data.get('samples_per_gpu', 1))
     if samples_per_gpu > 1:
-        disable_text_recog_aug_test(cfg)
-        replace_image_to_tensor(cfg)
+        cfg = disable_text_recog_aug_test(cfg)
+        cfg = replace_image_to_tensor(cfg)
 
     # init distributed env first, since logger depends on the dist info.
     if args.launcher == 'none':


### PR DESCRIPTION
For example, It is useful when datasets are stored in different devices (hard-disk, aws-ceph). In that way, different `pipelines` should be applied to different datasets.