### PR TITLE
[FIX] #665 fix change locals() dict

### DIFF
--- a/mmocr/utils/ocr.py
+++ b/mmocr/utils/ocr.py
@@ -411,7 +411,7 @@ class MMOCR:
                  merge=False,
                  merge_xdist=20,
                  **kwargs):
-        args = locals()
+        args = locals().copy()
         [args.pop(x, None) for x in ['kwargs', 'self']]
         args = Namespace(**args)
 


### PR DESCRIPTION
fix #665 

locals() dict should not be changed. [ref](https://docs.python.org/3/library/functions.html#locals)

If locals() runs more than once or during breakpoint debugging, the value of args will automatically become the dictionary before modification. 

In this case, a shallow copy is better.