### PR TITLE
[Fix] Fix opencv version to avoid some awared bugs

### DIFF
--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -4,6 +4,7 @@ lmdb
 matplotlib
 numba>=0.45.1
 numpy
+opencv-python-headless==4.5.4.60
 pyclipper
 rapidfuzz
 scikit-image

--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -4,7 +4,7 @@ lmdb
 matplotlib
 numba>=0.45.1
 numpy
-opencv-python-headless==4.5.4.60
+opencv-python-headless<=4.5.4.60
 pyclipper
 rapidfuzz
 scikit-image


### PR DESCRIPTION
`cv2.connectedComponents` in OpenCV 4.5.5.62 has bugs that cause seg fault. We circumvent this problem by fixing the version of `opencv-python-headless` to be no greater than 4.5.4.60. This change is intended to be reverted when the bug gets fixed in OpenCV's latest release.

Related issue: https://github.com/opencv/opencv/issues/21366