### PR TITLE
[Enhancement] Disable multi-processing feature of cv2 to speed up data loading

### DIFF
--- a/tools/train.py
+++ b/tools/train.py
@@ -7,6 +7,7 @@ import os.path as osp
 import time
 import warnings
 
+import cv2
 import mmcv
 import torch
 from mmcv import Config, DictAction
@@ -18,6 +19,8 @@ from mmocr.apis import init_random_seed, train_detector
 from mmocr.datasets import build_dataset
 from mmocr.models import build_detector
 from mmocr.utils import collect_env, get_root_logger, is_2dlist
+
+cv2.setNumThreads(0)
 
 
 def parse_args():


### PR DESCRIPTION
## Motivation

The multi-threading feature of cv2 is incompatible with our multi-worker data preprocessing pipeline. As reported by https://github.com/open-mmlab/mmdetection/pull/6867:

> The CPU is too busy to handle the threads making the whole training speed is slow, and the system also get very lagging. The reason is that the cv2 module will activate multi-processing automatically and the processes number is equal to the CPU core. Which means if you have a more powerful CPU, it hurts the performance harder. My server has a 64-core CPU and 8 T4 GPU, if I set the workers_per_gpu to 4, the number of cv2-threads will be 8*4*64 = 2048. If I set the workers_per_gpu to 8, there will be 4096 theads. Each of this will overwhleming my system.

I tried out this patch on ABINet whose data loading process heavily relies on cv2 and experienced significant speedup in datatime as well as the entire training duration. I will put up some statistics when I obtain the full log for 1 epoch.
