### PR TITLE
[Enhancement] Speed up training

### DIFF
--- a/configs/_base_/default_runtime.py
+++ b/configs/_base_/default_runtime.py
@@ -12,3 +12,8 @@ log_level = 'INFO'
 load_from = None
 resume_from = None
 workflow = [('train', 1)]
+
+# disable opencv multithreading to avoid system being overloaded
+opencv_num_threads = 0
+# set multi-process start method as `fork` to speed up the training
+mp_start_method = 'fork'

--- a/configs/_base_/runtime_10e.py
+++ b/configs/_base_/runtime_10e.py
@@ -12,3 +12,8 @@ log_level = 'INFO'
 load_from = None
 resume_from = None
 workflow = [('train', 1)]
+
+# disable opencv multithreading to avoid system being overloaded
+opencv_num_threads = 0
+# set multi-process start method as `fork` to speed up the training
+mp_start_method = 'fork'

--- a/tools/train.py
+++ b/tools/train.py
@@ -2,8 +2,10 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 import argparse
 import copy
+import multiprocessing as mp
 import os
 import os.path as osp
+import platform
 import time
 import warnings
 
@@ -19,8 +21,6 @@ from mmocr.apis import init_random_seed, train_detector
 from mmocr.datasets import build_dataset
 from mmocr.models import build_detector
 from mmocr.utils import collect_env, get_root_logger, is_2dlist
-
-cv2.setNumThreads(0)
 
 
 def parse_args():
@@ -91,12 +91,25 @@ def parse_args():
     return args
 
 
+def setup_multi_processes(cfg):
+    # set multi-process start method as `fork` to speed up the training
+    if platform.system() != 'Windows':
+        mp_start_method = cfg.get('mp_start_method', 'fork')
+        mp.set_start_method(mp_start_method)
+
+    # disable opencv multithreading to avoid system being overloaded
+    opencv_num_threads = cfg.get('opencv_num_threads', 0)
+    cv2.setNumThreads(opencv_num_threads)
+
+
 def main():
     args = parse_args()
 
     cfg = Config.fromfile(args.config)
     if args.cfg_options is not None:
         cfg.merge_from_dict(args.cfg_options)
+
+    setup_multi_processes(cfg)
 
     # set cudnn_benchmark
     if cfg.get('cudnn_benchmark', False):


### PR DESCRIPTION
## Motivation

Related PR: https://github.com/open-mmlab/mmdetection/pull/6974/files

Setting num_threads of OpenCV to 0 and `mp_start_method` to `fork` can speed up the overall training process. This PR allows user to configure these values in configs.

However, I've run multiple experiments which showed that restricting MKL and OMP threads rather slows down the training. Therefore, this PR does not implement relevant configuration.