### PR TITLE
[Fix] Use yaml.safe_load instead of load

### DIFF
--- a/tools/data/textdet/totaltext_converter.py
+++ b/tools/data/textdet/totaltext_converter.py
@@ -180,7 +180,7 @@ def process_line(line, contours, words):
     ann_dict = re.sub('([0-9]) +([ 0-9])', r'\1,\2', ann_dict)
     ann_dict = re.sub('([0-9]) -([0-9])', r'\1,-\2', ann_dict)
     ann_dict = ann_dict.replace("[u',']", "[u'#']")
-    ann_dict = yaml.load(ann_dict)
+    ann_dict = yaml.safe_load(ann_dict)
 
     X = np.array([ann_dict['x']])
     Y = np.array([ann_dict['y']])

--- a/tools/data/textrecog/totaltext_converter.py
+++ b/tools/data/textrecog/totaltext_converter.py
@@ -169,7 +169,7 @@ def process_line(line, contours, words):
     ann_dict = re.sub('([0-9]) +([ 0-9])', r'\1,\2', ann_dict)
     ann_dict = re.sub('([0-9]) -([0-9])', r'\1,-\2', ann_dict)
     ann_dict = ann_dict.replace("[u',']", "[u'#']")
-    ann_dict = yaml.load(ann_dict)
+    ann_dict = yaml.safe_load(ann_dict)
 
     X = np.array([ann_dict['x']])
     Y = np.array([ann_dict['y']])


### PR DESCRIPTION
## Motivation

`yaml.load` has long been regarded as vulnerable and a certain type of loader has to be explicitly specified starting from `pyyaml==6.0`, which breaks our totaltext converters. Using `safe_load` to parse totaltext is just enough and officially recommended.

Fixes #751

## Modification

`yaml.load` -> `yaml.safe_load` for both totaltext dataset converters.

## BC-Breaking
None. `safe_load` is supported by older `pyyaml` as well.