### PR TITLE
[Fix] Add necessary keys to test_pipelines to enable test-time visualization

### DIFF
--- a/configs/_base_/recog_pipelines/abinet_pipeline.py
+++ b/configs/_base_/recog_pipelines/abinet_pipeline.py
@@ -90,7 +90,7 @@ test_pipeline = [
                 keys=['img'],
                 meta_keys=[
                     'filename', 'ori_shape', 'img_shape', 'valid_ratio',
-                    'resize_shape'
+                    'resize_shape', 'img_norm_cfg', 'ori_filename'
                 ]),
         ])
 ]

--- a/configs/_base_/recog_pipelines/crnn_pipeline.py
+++ b/configs/_base_/recog_pipelines/crnn_pipeline.py
@@ -28,5 +28,8 @@ test_pipeline = [
     dict(
         type='Collect',
         keys=['img'],
-        meta_keys=['filename', 'resize_shape', 'valid_ratio']),
+        meta_keys=[
+            'filename', 'resize_shape', 'valid_ratio', 'img_norm_cfg',
+            'ori_filename', 'img_shape', 'ori_shape'
+        ]),
 ]

--- a/configs/_base_/recog_pipelines/crnn_tps_pipeline.py
+++ b/configs/_base_/recog_pipelines/crnn_tps_pipeline.py
@@ -30,5 +30,8 @@ test_pipeline = [
     dict(
         type='Collect',
         keys=['img'],
-        meta_keys=['filename', 'ori_shape', 'resize_shape', 'valid_ratio']),
+        meta_keys=[
+            'filename', 'ori_shape', 'resize_shape', 'valid_ratio',
+            'img_norm_cfg', 'ori_filename', 'img_shape'
+        ]),
 ]

--- a/configs/_base_/recog_pipelines/nrtr_pipeline.py
+++ b/configs/_base_/recog_pipelines/nrtr_pipeline.py
@@ -31,5 +31,8 @@ test_pipeline = [
     dict(
         type='Collect',
         keys=['img'],
-        meta_keys=['filename', 'ori_shape', 'resize_shape', 'valid_ratio'])
+        meta_keys=[
+            'filename', 'ori_shape', 'resize_shape', 'valid_ratio',
+            'img_norm_cfg', 'ori_filename', 'img_shape'
+        ])
 ]

--- a/configs/_base_/recog_pipelines/sar_pipeline.py
+++ b/configs/_base_/recog_pipelines/sar_pipeline.py
@@ -36,7 +36,8 @@ test_pipeline = [
                 type='Collect',
                 keys=['img'],
                 meta_keys=[
-                    'filename', 'ori_shape', 'resize_shape', 'valid_ratio'
+                    'filename', 'ori_shape', 'resize_shape', 'valid_ratio',
+                    'img_norm_cfg', 'ori_filename', 'img_shape'
                 ]),
         ])
 ]

--- a/configs/_base_/recog_pipelines/satrn_pipeline.py
+++ b/configs/_base_/recog_pipelines/satrn_pipeline.py
@@ -38,7 +38,7 @@ test_pipeline = [
                 keys=['img'],
                 meta_keys=[
                     'filename', 'ori_shape', 'img_shape', 'valid_ratio',
-                    'resize_shape'
+                    'resize_shape', 'img_norm_cfg', 'ori_filename'
                 ]),
         ])
 ]

--- a/configs/_base_/recog_pipelines/seg_pipeline.py
+++ b/configs/_base_/recog_pipelines/seg_pipeline.py
@@ -59,5 +59,8 @@ test_pipeline = [
     dict(
         type='Collect',
         keys=['img'],
-        meta_keys=['filename', 'ori_shape', 'resize_shape'])
+        meta_keys=[
+            'filename', 'resize_shape', 'img_norm_cfg', 'ori_filename',
+            'img_shape', 'ori_shape'
+        ])
 ]

--- a/configs/kie/sdmgr/sdmgr_novisual_60e_wildreceipt.py
+++ b/configs/kie/sdmgr/sdmgr_novisual_60e_wildreceipt.py
@@ -20,7 +20,8 @@ test_pipeline = [
     dict(
         type='Collect',
         keys=['img', 'relations', 'texts', 'gt_bboxes'],
-        meta_keys=('filename', 'ori_texts'))
+        meta_keys=('filename', 'ori_texts', 'img_norm_cfg', 'ori_filename',
+                   'img_shape'))
 ]
 
 dataset_type = 'KIEDataset'

--- a/configs/kie/sdmgr/sdmgr_novisual_60e_wildreceipt_openset.py
+++ b/configs/kie/sdmgr/sdmgr_novisual_60e_wildreceipt_openset.py
@@ -37,7 +37,8 @@ test_pipeline = [
     dict(
         type='Collect',
         keys=['img', 'relations', 'texts', 'gt_bboxes'],
-        meta_keys=('filename', 'ori_filename', 'ori_texts', 'ori_boxes'))
+        meta_keys=('filename', 'ori_filename', 'ori_texts', 'ori_boxes',
+                   'img_norm_cfg', 'ori_filename', 'img_shape'))
 ]
 
 dataset_type = 'OpensetKIEDataset'


### PR DESCRIPTION
## Motivation

The configuration files didn't collect the necessary keys for test-time visualization and now it's fixed. Note that the pipelines of text detection models are not changed because the `Collect` transform will collect all necessary keys by default when `meta_keys` is not overridden.

## Modification

For all test pipelines, I added necessary `meta_keys` to `Collect` for visualization.