### PR TITLE
[Fix] Minimum version requirement of albumentations

### DIFF
--- a/requirements/optional.txt
+++ b/requirements/optional.txt
@@ -1,0 +1,1 @@
+albumentations>=1.1.0


### PR DESCRIPTION
## Motivation

Legacy `albumentations` does not have some necessary features to support `Albu` pipeline wrapper from MMDetection. This PR requires users to use the newer one. Fixes #767

## Detail
In legacy `albumentations`, the `Compose` method  does not accept `None` as `bbox_params` which is possible to happen in 
https://github.com/open-mmlab/mmdetection/blob/6ead4503a876971ed4d95d0cce9e9dc7ab8db31b/mmdet/datasets/pipelines/transforms.py#L1390-L1393