### PR TITLE
update mmcv install

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,24 +87,24 @@ jobs:
         torch: [1.6.0+cu101, 1.7.0+cu101, 1.8.0+cu101]
         include:
           - torch: 1.6.0+cu101
-            torch_version: 1.6.0
+            torch_version: 1.6
             torchvision: 0.7.0+cu101
           - torch: 1.7.0+cu101
-            torch_version: 1.7.0
+            torch_version: 1.7
             torchvision: 0.8.1+cu101
           - torch: 1.8.0+cu101
-            torch_version: 1.8.0
+            torch_version: 1.8
             torchvision: 0.9.0+cu101
           - torch: 1.8.0+cu101
-            torch_version: 1.8.0
+            torch_version: 1.8
             torchvision: 0.9.0+cu101
             python-version: 3.6
           - torch: 1.8.0+cu101
-            torch_version: 1.8.0
+            torch_version: 1.8
             torchvision: 0.9.0+cu101
             python-version: 3.8
           - torch: 1.8.0+cu101
-            torch_version: 1.8.0
+            torch_version: 1.8
             torchvision: 0.9.0+cu101
             python-version: 3.9
     steps:
@@ -176,14 +176,14 @@ jobs:
         torch: [1.9.0+cu102]
         include:
           - torch: 1.9.0+cu102
-            torch_version: 1.9.0
+            torch_version: 1.9
             torchvision: 0.10.0+cu102
           - torch: 1.9.0+cu102
-            torch_version: 1.9.0
+            torch_version: 1.9
             torchvision: 0.10.0+cu102
             python-version: 3.8
           - torch: 1.9.0+cu102
-            torch_version: 1.9.0
+            torch_version: 1.9
             torchvision: 0.10.0+cu102
             python-version: 3.9
     steps:

--- a/docs/en/install.md
+++ b/docs/en/install.md
@@ -56,6 +56,12 @@ Please replace ``{cu_version}`` and ``{torch_version}`` in the url with your des
 ```shell
 pip install mmcv-full -f https://download.openmmlab.com/mmcv/dist/cu110/torch1.7.0/index.html
 ```
+mmcv-full is only compiled on PyTorch 1.x.0 because the compatibility usually holds between 1.x.0 and 1.x.1. If your PyTorch version is 1.x.1, you can install mmcv-full compiled with PyTorch 1.x.0 and it usually works well.
+
+    ```
+    # We can ignore the micro version of PyTorch
+    pip install mmcv-full -f https://download.openmmlab.com/mmcv/dist/cu110/torch1.7/index.html
+    ```
 :::{note}
 Note that mmocr 0.2.1 or later requires mmcv 1.3.8 or later.
 

--- a/docs/en/install.md
+++ b/docs/en/install.md
@@ -56,12 +56,14 @@ Please replace ``{cu_version}`` and ``{torch_version}`` in the url with your des
 ```shell
 pip install mmcv-full -f https://download.openmmlab.com/mmcv/dist/cu110/torch1.7.0/index.html
 ```
+:::{note}
 mmcv-full is only compiled on PyTorch 1.x.0 because the compatibility usually holds between 1.x.0 and 1.x.1. If your PyTorch version is 1.x.1, you can install mmcv-full compiled with PyTorch 1.x.0 and it usually works well.
 
     ```
     # We can ignore the micro version of PyTorch
     pip install mmcv-full -f https://download.openmmlab.com/mmcv/dist/cu110/torch1.7/index.html
     ```
+:::
 :::{note}
 Note that mmocr 0.2.1 or later requires mmcv 1.3.8 or later.
 

--- a/docs/zh_cn/install.md
+++ b/docs/zh_cn/install.md
@@ -54,6 +54,12 @@ pip install mmcv-full -f https://download.openmmlab.com/mmcv/dist/{cu_version}/{
 ```shell
 pip install mmcv-full -f https://download.openmmlab.com/mmcv/dist/cu110/torch1.7.0/index.html
 ```
+PyTorch 在 1.x.0 和 1.x.1 之间通常是兼容的，故 mmcv-full 只提供 1.x.0 的编译包。如果你的 PyTorch 版本是 1.x.1，你可以放心地安装在 1.x.0 版本编译的 mmcv-full。
+
+```
+# 我们可以忽略 PyTorch 的小版本号
+pip install mmcv-full -f https://download.openmmlab.com/mmcv/dist/cu110/torch1.7/index.html
+```
 :::{note}
 使用 mmocr 0.2.0 及更高版本需要安装 mmcv 1.3.4 或更高版本。
 

--- a/docs/zh_cn/install.md
+++ b/docs/zh_cn/install.md
@@ -54,12 +54,14 @@ pip install mmcv-full -f https://download.openmmlab.com/mmcv/dist/{cu_version}/{
 ```shell
 pip install mmcv-full -f https://download.openmmlab.com/mmcv/dist/cu110/torch1.7.0/index.html
 ```
+:::{note}
 PyTorch 在 1.x.0 和 1.x.1 之间通常是兼容的，故 mmcv-full 只提供 1.x.0 的编译包。如果你的 PyTorch 版本是 1.x.1，你可以放心地安装在 1.x.0 版本编译的 mmcv-full。
 
 ```
 # 我们可以忽略 PyTorch 的小版本号
 pip install mmcv-full -f https://download.openmmlab.com/mmcv/dist/cu110/torch1.7/index.html
 ```
+:::
 :::{note}
 使用 mmocr 0.2.0 及更高版本需要安装 mmcv 1.3.4 或更高版本。
 


### PR DESCRIPTION

## Motivation

mmcv-full is only compiled on PyTorch 1.x.0 because the compatibility usually holds between 1.x.0 and 1.x.1. If your PyTorch version is 1.x.1, you can install mmcv-full compiled with PyTorch 1.x.0 and it usually works well.

https://github.com/open-mmlab/mmtracking/pull/409