### PR TITLE
[Fix] Disable worker in the dataloader of gpu unit test

### DIFF
--- a/tests/test_apis/test_single_gpu_test.py
+++ b/tests/test_apis/test_single_gpu_test.py
@@ -43,7 +43,7 @@ def generate_sample_dataloader(cfg, curr_dir, img_prefix='', ann_file=''):
     test = copy.deepcopy(cfg.data.test.datasets[0])
     test.img_prefix = img_prefix
     test.ann_file = ann_file
-    cfg.data.workers_per_gpu = 1
+    cfg.data.workers_per_gpu = 0
     cfg.data.test.datasets = [test]
     dataset = build_dataset(cfg.data.test)
 


### PR DESCRIPTION
## Motivation

We used a worker in dataloader to pre-fetch data in gpu-only unit test which would use some shared memory. However, some docker containers limit the size of shared memory by default, and running such test on them throws "out of shared memory" error:

```
RuntimeError: DataLoader worker (pid 53617) is killed by signal: Bus error. It is possible that dataloader's workers are out of shared memory. Please try to raise your shared memory limit.
```

This can be fixed by disabling workers and using a single thread instead.

## Reference
https://discuss.pytorch.org/t/training-crashes-due-to-insufficient-shared-memory-shm-nn-dataparallel/26396/16