### PR TITLE
[Fix] Standardize the type of torch.device in ocr.py

### DIFF
--- a/mmocr/utils/ocr.py
+++ b/mmocr/utils/ocr.py
@@ -329,8 +329,8 @@ class MMOCR:
         self.kie = kie
         self.device = device
         if self.device is None:
-            self.device = torch.cuda.current_device() \
-                if torch.cuda.is_available() else 'cpu'
+            self.device = torch.device(
+                'cuda' if torch.cuda.is_available() else 'cpu')
 
         # Check if the det/recog model choice is valid
         if self.td and self.td not in textdet_models:

--- a/tests/test_utils/test_ocr.py
+++ b/tests/test_utils/test_ocr.py
@@ -81,6 +81,8 @@ def test_ocr_init(mock_loading, mock_config, mock_build_detector,
 
     def loadcheckpoint_assert(*args, **kwargs):
         assert args[1] == gt_ckpt[-1]
+        assert kwargs['map_location'] == torch.device(
+            'cuda' if torch.cuda.is_available() else 'cpu')
 
     mock_loading.side_effect = loadcheckpoint_assert
     with mock.patch('mmocr.utils.ocr.revert_sync_batchnorm'):
@@ -105,8 +107,7 @@ def test_ocr_init(mock_loading, mock_config, mock_build_detector,
             mock_config.assert_called_with(gt_cfg[-1])
             mock_build_detector.assert_called_once()
             mock_loading.assert_called_once()
-        device = torch.cuda.current_device() if \
-            torch.cuda.is_available() else 'cpu'
+        device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
         calls = [
             mock.call(gt_cfg[i], gt_ckpt[i], device=device) for i in i_range
         ]
@@ -167,8 +168,7 @@ def test_ocr_init_customize_config(mock_loading, mock_config,
             mock_config.assert_called_with(gt_cfg[-1])
             mock_build_detector.assert_called_once()
             mock_loading.assert_called_once()
-        device = torch.cuda.current_device() if \
-            torch.cuda.is_available() else 'cpu'
+        device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
         calls = [
             mock.call(gt_cfg[i], gt_ckpt[i], device=device) for i in i_range
         ]


### PR DESCRIPTION
Fixes #796 

## Motivation

`mmocr.utils.ocr` can detect user's device but didn't wrap the result by `torch.device`. Therefore, the type of `MMOCR.device` is different case by case and can break some functions, such as `load_checkpoint`, that didn't manage to handle all possible input types.

## Modification

Wrap the device result by `torch.device` and update unit tests accordingly.
