### PR TITLE
Add deprecation message for deploy tools

### DIFF
--- a/tools/deployment/deploy_test.py
+++ b/tools/deployment/deploy_test.py
@@ -46,6 +46,19 @@ def parse_args():
 
 def main():
     args = parse_args()
+
+    # Following strings of text style are from colorama package
+    bright_style, reset_style = '\x1b[1m', '\x1b[0m'
+    red_text, blue_text = '\x1b[31m', '\x1b[34m'
+    white_background = '\x1b[107m'
+
+    msg = white_background + bright_style + red_text
+    msg += 'DeprecationWarning: This tool will be deprecated in future. '
+    msg += blue_text + 'Welcome to use the unified model deployment toolbox '
+    msg += 'MMDeploy: https://github.com/open-mmlab/mmdeploy'
+    msg += reset_style
+    warnings.warn(msg)
+
     if args.device == 'cpu':
         args.device = None
 
@@ -94,15 +107,3 @@ def main():
 
 if __name__ == '__main__':
     main()
-
-    # Following strings of text style are from colorama package
-    bright_style, reset_style = '\x1b[1m', '\x1b[0m'
-    red_text, blue_text = '\x1b[31m', '\x1b[34m'
-    white_background = '\x1b[107m'
-
-    msg = white_background + bright_style + red_text
-    msg += 'DeprecationWarning: This tool will be deprecated in future. '
-    msg += blue_text + 'Welcome to use the unified model deployment toolbox '
-    msg += 'MMDeploy: https://github.com/open-mmlab/mmdeploy'
-    msg += reset_style
-    warnings.warn(msg)

--- a/tools/deployment/deploy_test.py
+++ b/tools/deployment/deploy_test.py
@@ -1,5 +1,6 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 import argparse
+import warnings
 
 from mmcv import Config
 from mmcv.parallel import MMDataParallel
@@ -93,3 +94,15 @@ def main():
 
 if __name__ == '__main__':
     main()
+
+    # Following strings of text style are from colorama package
+    bright_style, reset_style = '\x1b[1m', '\x1b[0m'
+    red_text, blue_text = '\x1b[31m', '\x1b[34m'
+    white_background = '\x1b[107m'
+
+    msg = white_background + bright_style + red_text
+    msg += 'DeprecationWarning: This tool will be deprecated in future. '
+    msg += blue_text + 'Welcome to use the unified model deployment toolbox '
+    msg += 'MMDeploy: https://github.com/open-mmlab/mmdeploy'
+    msg += reset_style
+    warnings.warn(msg)

--- a/tools/deployment/onnx2tensorrt.py
+++ b/tools/deployment/onnx2tensorrt.py
@@ -243,6 +243,18 @@ if __name__ == '__main__':
     assert is_tensorrt_plugin_loaded(), 'TensorRT plugin should be compiled.'
     args = parse_args()
 
+    # Following strings of text style are from colorama package
+    bright_style, reset_style = '\x1b[1m', '\x1b[0m'
+    red_text, blue_text = '\x1b[31m', '\x1b[34m'
+    white_background = '\x1b[107m'
+
+    msg = white_background + bright_style + red_text
+    msg += 'DeprecationWarning: This tool will be deprecated in future. '
+    msg += blue_text + 'Welcome to use the unified model deployment toolbox '
+    msg += 'MMDeploy: https://github.com/open-mmlab/mmdeploy'
+    msg += reset_style
+    warnings.warn(msg)
+
     # check arguments
     assert osp.exists(args.model_config), 'Config {} not found.'.format(
         args.model_config)
@@ -280,15 +292,3 @@ if __name__ == '__main__':
         show=args.show,
         workspace_size=args.workspace_size,
         verbose=args.verbose)
-
-    # Following strings of text style are from colorama package
-    bright_style, reset_style = '\x1b[1m', '\x1b[0m'
-    red_text, blue_text = '\x1b[31m', '\x1b[34m'
-    white_background = '\x1b[107m'
-
-    msg = white_background + bright_style + red_text
-    msg += 'DeprecationWarning: This tool will be deprecated in future. '
-    msg += blue_text + 'Welcome to use the unified model deployment toolbox '
-    msg += 'MMDeploy: https://github.com/open-mmlab/mmdeploy'
-    msg += reset_style
-    warnings.warn(msg)

--- a/tools/deployment/onnx2tensorrt.py
+++ b/tools/deployment/onnx2tensorrt.py
@@ -2,6 +2,7 @@
 import argparse
 import os
 import os.path as osp
+import warnings
 from typing import Iterable
 
 import cv2
@@ -279,3 +280,15 @@ if __name__ == '__main__':
         show=args.show,
         workspace_size=args.workspace_size,
         verbose=args.verbose)
+
+    # Following strings of text style are from colorama package
+    bright_style, reset_style = '\x1b[1m', '\x1b[0m'
+    red_text, blue_text = '\x1b[31m', '\x1b[34m'
+    white_background = '\x1b[107m'
+
+    msg = white_background + bright_style + red_text
+    msg += 'DeprecationWarning: This tool will be deprecated in future. '
+    msg += blue_text + 'Welcome to use the unified model deployment toolbox '
+    msg += 'MMDeploy: https://github.com/open-mmlab/mmdeploy'
+    msg += reset_style
+    warnings.warn(msg)

--- a/tools/deployment/pytorch2onnx.py
+++ b/tools/deployment/pytorch2onnx.py
@@ -1,4 +1,5 @@
 # Copyright (c) OpenMMLab. All rights reserved.
+import warnings
 from argparse import ArgumentParser
 from functools import partial
 
@@ -353,3 +354,15 @@ def main():
 
 if __name__ == '__main__':
     main()
+
+    # Following strings of text style are from colorama package
+    bright_style, reset_style = '\x1b[1m', '\x1b[0m'
+    red_text, blue_text = '\x1b[31m', '\x1b[34m'
+    white_background = '\x1b[107m'
+
+    msg = white_background + bright_style + red_text
+    msg += 'DeprecationWarning: This tool will be deprecated in future. '
+    msg += blue_text + 'Welcome to use the unified model deployment toolbox '
+    msg += 'MMDeploy: https://github.com/open-mmlab/mmdeploy'
+    msg += reset_style
+    warnings.warn(msg)

--- a/tools/deployment/pytorch2onnx.py
+++ b/tools/deployment/pytorch2onnx.py
@@ -323,6 +323,18 @@ def main():
         default=False)
     args = parser.parse_args()
 
+    # Following strings of text style are from colorama package
+    bright_style, reset_style = '\x1b[1m', '\x1b[0m'
+    red_text, blue_text = '\x1b[31m', '\x1b[34m'
+    white_background = '\x1b[107m'
+
+    msg = white_background + bright_style + red_text
+    msg += 'DeprecationWarning: This tool will be deprecated in future. '
+    msg += blue_text + 'Welcome to use the unified model deployment toolbox '
+    msg += 'MMDeploy: https://github.com/open-mmlab/mmdeploy'
+    msg += reset_style
+    warnings.warn(msg)
+
     device = torch.device(type='cuda', index=args.device_id)
 
     # build model
@@ -354,15 +366,3 @@ def main():
 
 if __name__ == '__main__':
     main()
-
-    # Following strings of text style are from colorama package
-    bright_style, reset_style = '\x1b[1m', '\x1b[0m'
-    red_text, blue_text = '\x1b[31m', '\x1b[34m'
-    white_background = '\x1b[107m'
-
-    msg = white_background + bright_style + red_text
-    msg += 'DeprecationWarning: This tool will be deprecated in future. '
-    msg += blue_text + 'Welcome to use the unified model deployment toolbox '
-    msg += 'MMDeploy: https://github.com/open-mmlab/mmdeploy'
-    msg += reset_style
-    warnings.warn(msg)


### PR DESCRIPTION
## Motivation

Since [MMDeploy](https://github.com/open-mmlab/mmdeploy) has been released, the deployment tools scattered in each OpenMMLab codebase will be deprecated in the future.

## Modification

Add deprecation message in deployment tools.

## Use cases (Optional)

![image](https://user-images.githubusercontent.com/45810070/155935420-220fc5b0-be4a-427d-b899-91fcb70c604e.png)

