### PR TITLE
[Fix] Add num_classes to configs of ABINet

### DIFF
--- a/configs/_base_/recog_models/abinet.py
+++ b/configs/_base_/recog_models/abinet.py
@@ -56,7 +56,11 @@ model = dict(
         max_seq_len=max_seq_len,
     ),
     loss=dict(
-        type='ABILoss', enc_weight=1.0, dec_weight=1.0, fusion_weight=1.0),
+        type='ABILoss',
+        enc_weight=1.0,
+        dec_weight=1.0,
+        fusion_weight=1.0,
+        num_classes=num_chars),
     label_convertor=label_convertor,
     max_seq_len=max_seq_len,
     iter_size=3)

--- a/configs/_base_/recog_models/abinet.py
+++ b/configs/_base_/recog_models/abinet.py
@@ -1,3 +1,7 @@
+# num_chars depends on the configuration of label_convertor. The actual
+# dictionary size is 36 + 1 (<BOS/EOS>).
+# TODO: Automatically update num_chars based on the configuration of
+# label_convertor
 num_chars = 37
 max_seq_len = 26
 

--- a/configs/textrecog/abinet/abinet_vision_only_academic.py
+++ b/configs/textrecog/abinet/abinet_vision_only_academic.py
@@ -50,7 +50,11 @@ model = dict(
             init_cfg=dict(type='Xavier', layer='Conv2d')),
     ),
     loss=dict(
-        type='ABILoss', enc_weight=1.0, dec_weight=1.0, fusion_weight=1.0),
+        type='ABILoss',
+        enc_weight=1.0,
+        dec_weight=1.0,
+        fusion_weight=1.0,
+        num_classes=num_chars),
     label_convertor=label_convertor,
     max_seq_len=max_seq_len,
     iter_size=1)


### PR DESCRIPTION
Without `num_classes=num_chars` specified in `ABILoss`, users who want to adapt the architecture to the dictionary size by changing `num_chars` only would encounter an error in loss computation.

Ref: #803 