### PR TITLE
[Fix] ignore_index in SARLoss

### DIFF
--- a/mmocr/models/textrecog/losses/ce_loss.py
+++ b/mmocr/models/textrecog/losses/ce_loss.py
@@ -79,7 +79,7 @@ class SARLoss(CELoss):
         SARLoss assumes that the first input token is always `<SOS>`.
     """
 
-    def __init__(self, ignore_index=0, reduction='mean', **kwargs):
+    def __init__(self, ignore_index=-1, reduction='mean', **kwargs):
         super().__init__(ignore_index, reduction)
 
     def format(self, outputs, targets_dict):

--- a/tools/data/utils/txt2lmdb.py
+++ b/tools/data/utils/txt2lmdb.py
@@ -24,8 +24,7 @@ def main():
     parser.add_argument(
         '--lmdb_map_size',
         '-l',
-        type=int,
-        default=109951162776,
+        default='109951162776',
         help='maximum size database may grow to , default 109951162776 bytes')
     opt = parser.parse_args()
 

--- a/tools/data/utils/txt2lmdb.py
+++ b/tools/data/utils/txt2lmdb.py
@@ -24,7 +24,8 @@ def main():
     parser.add_argument(
         '--lmdb_map_size',
         '-l',
-        default='109951162776',
+        type=int,
+        default=109951162776,
         help='maximum size database may grow to , default 109951162776 bytes')
     opt = parser.parse_args()
 


### PR DESCRIPTION
## Motivation
When caculating `CrossEntropy `loss in attention decoder, we can assign `ignore_index` to skip the loss of `<PAD>` token. In MMOCR, this assigning process is automatically done at [here](https://github.com/open-mmlab/mmocr/blob/main/mmocr/models/textrecog/recognizer/encode_decode_recognizer.py#L60)
```python
loss.update(ignore_index=self.label_convertor.padding_idx)
```
However, in [SARLoss](https://github.com/open-mmlab/mmocr/blob/main/mmocr/models/textrecog/losses/ce_loss.py#L67), the ignore index is initialized as `0` which may cause confusing, even if it won't work as we can automatically update the `ignore_index`. So we'd like to reset this value to `-1`.

