### PR TITLE
[Fix] Fix CircleCi Main Branch Accidentally Run PR Stage Test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,18 +1,6 @@
 version: 2.1
 
 jobs:
-  test:
-    docker:
-      - image: cimg/python:3.7.4
-    steps:
-      - checkout
-      - run:
-          command: |
-            echo << pipeline.git.branch >>
-            echo << pipeline.id >>
-            echo << pipeline.number >>
-            echo << pipeline.schedule.name >>
-            echo << pipeline.schedule.id >>
   lint:
     docker:
       - image: cimg/python:3.7.4
@@ -135,13 +123,13 @@ jobs:
 workflows:
   pr_stage_test:
     jobs:
-      - test
-  #     - lint:
-  #         name: lint
-  #         filters:
-  #           branches:
-  #             only:
-  #               - /pull.*/
+      - lint:
+          name: lint
+          filters:
+            branches:
+              only:
+                - /pull.*/
+                - << pipeline.git.branch >>
   #     - build_cpu:
   #         name: minimum_version_cpu
   #         torch: 1.6.0

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,12 +7,12 @@ jobs:
     steps:
       - checkout
       - run:
-        command: |
-          echo << pipeline.git.branch >>
-          echo << pipeline.id >>
-          echo << pipeline.number >>
-          echo << pipeline.schedule.name >>
-          echo << pipeline.schedule.id >>
+          command: |
+            echo << pipeline.git.branch >>
+            echo << pipeline.id >>
+            echo << pipeline.number >>
+            echo << pipeline.schedule.name >>
+            echo << pipeline.schedule.id >>
   lint:
     docker:
       - image: cimg/python:3.7.4

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,18 @@
 version: 2.1
 
 jobs:
+  test:
+    docker:
+      - image: cimg/python:3.7.4
+    steps:
+      - checkout
+      - run:
+        command: |
+          echo << pipeline.git.branch >>
+          echo << pipeline.id >>
+          echo << pipeline.number >>
+          echo << pipeline.schedule.name >>
+          echo << pipeline.schedule.id >>
   lint:
     docker:
       - image: cimg/python:3.7.4
@@ -123,46 +135,47 @@ jobs:
 workflows:
   pr_stage_test:
     jobs:
-      - lint:
-          name: lint
-          filters:
-            branches:
-              only:
-                - /pull.*/
-      - build_cpu:
-          name: minimum_version_cpu
-          torch: 1.6.0
-          torchvision: 0.7.0
-          python: 3.6.9  # The lowest python 3.6.x version available on CircleCI images
-          requires:
-            - lint
-      - build_cpu:
-          name: maximum_version_cpu
-          torch: 1.9.0
-          torchvision: 0.10.0
-          python: 3.9.0
-          requires:
-            - minimum_version_cpu
-      - hold:
-          type: approval
-          requires:
-            - maximum_version_cpu
-      - build_cuda:
-          name: mainstream_version_gpu
-          torch: 1.8.1
-          torchvision: 0.9.1
-          python: 3.8.6
-          requires:
-            - hold
-  merge_stage_test:
-    jobs:
-      - build_cuda:
-          name: minimum_version_gpu
-          torch: 1.6.0
-          torchvision: 0.7.0
-          python: 3.6.12
-          cuda: cu101
-          filters:
-            branches:
-              only:
-                - main
+      - test
+  #     - lint:
+  #         name: lint
+  #         filters:
+  #           branches:
+  #             only:
+  #               - /pull.*/
+  #     - build_cpu:
+  #         name: minimum_version_cpu
+  #         torch: 1.6.0
+  #         torchvision: 0.7.0
+  #         python: 3.6.9  # The lowest python 3.6.x version available on CircleCI images
+  #         requires:
+  #           - lint
+  #     - build_cpu:
+  #         name: maximum_version_cpu
+  #         torch: 1.9.0
+  #         torchvision: 0.10.0
+  #         python: 3.9.0
+  #         requires:
+  #           - minimum_version_cpu
+  #     - hold:
+  #         type: approval
+  #         requires:
+  #           - maximum_version_cpu
+  #     - build_cuda:
+  #         name: mainstream_version_gpu
+  #         torch: 1.8.1
+  #         torchvision: 0.9.1
+  #         python: 3.8.6
+  #         requires:
+  #           - hold
+  # merge_stage_test:
+  #   jobs:
+  #     - build_cuda:
+  #         name: minimum_version_gpu
+  #         torch: 1.6.0
+  #         torchvision: 0.7.0
+  #         python: 3.6.12
+  #         cuda: cu101
+  #         filters:
+  #           branches:
+  #             only:
+  #               - main

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -130,40 +130,40 @@ workflows:
               only:
                 - /pull.*/
                 - << pipeline.git.branch >>
-  #     - build_cpu:
-  #         name: minimum_version_cpu
-  #         torch: 1.6.0
-  #         torchvision: 0.7.0
-  #         python: 3.6.9  # The lowest python 3.6.x version available on CircleCI images
-  #         requires:
-  #           - lint
-  #     - build_cpu:
-  #         name: maximum_version_cpu
-  #         torch: 1.9.0
-  #         torchvision: 0.10.0
-  #         python: 3.9.0
-  #         requires:
-  #           - minimum_version_cpu
-  #     - hold:
-  #         type: approval
-  #         requires:
-  #           - maximum_version_cpu
-  #     - build_cuda:
-  #         name: mainstream_version_gpu
-  #         torch: 1.8.1
-  #         torchvision: 0.9.1
-  #         python: 3.8.6
-  #         requires:
-  #           - hold
-  # merge_stage_test:
-  #   jobs:
-  #     - build_cuda:
-  #         name: minimum_version_gpu
-  #         torch: 1.6.0
-  #         torchvision: 0.7.0
-  #         python: 3.6.12
-  #         cuda: cu101
-  #         filters:
-  #           branches:
-  #             only:
-  #               - main
+      - build_cpu:
+          name: minimum_version_cpu
+          torch: 1.6.0
+          torchvision: 0.7.0
+          python: 3.6.9  # The lowest python 3.6.x version available on CircleCI images
+          requires:
+            - lint
+      - build_cpu:
+          name: maximum_version_cpu
+          torch: 1.9.0
+          torchvision: 0.10.0
+          python: 3.9.0
+          requires:
+            - minimum_version_cpu
+      - hold:
+          type: approval
+          requires:
+            - maximum_version_cpu
+      - build_cuda:
+          name: mainstream_version_gpu
+          torch: 1.8.1
+          torchvision: 0.9.1
+          python: 3.8.6
+          requires:
+            - hold
+  merge_stage_test:
+    jobs:
+      - build_cuda:
+          name: minimum_version_gpu
+          torch: 1.6.0
+          torchvision: 0.7.0
+          python: 3.6.12
+          cuda: cu101
+          filters:
+            branches:
+              only:
+                - main


### PR DESCRIPTION
## Motivation

Due to the filtering rule, the main branch commits may run the PR stage Test after submitting a new Pull Request.

## Revision

Now the filtering rule is updated by adding `<< pipeline.git.branch >>`, so the test can only be triggered by its own branches.

```yaml
filters:
  branches:
    only:
      - /pull.*/
      - << pipeline.git.branch >>
```