### PR TITLE
[Enhancement] Support dynamic threshold range in eval_hmean

### DIFF
--- a/configs/textdet/dbnet/dbnet_r18_fpnc_1200e_icdar2015.py
+++ b/configs/textdet/dbnet/dbnet_r18_fpnc_1200e_icdar2015.py
@@ -30,4 +30,9 @@ data = dict(
         datasets=test_list,
         pipeline=test_pipeline_1333_736))
 
-evaluation = dict(interval=100, metric='hmean-iou')
+evaluation = dict(
+    interval=100,
+    metric='hmean-iou',
+    min_score_thr=0.1,
+    max_score_thr=0.5,
+    step=0.1)

--- a/mmocr/core/evaluation/hmean.py
+++ b/mmocr/core/evaluation/hmean.py
@@ -1,4 +1,5 @@
 # Copyright (c) OpenMMLab. All rights reserved.
+import warnings
 from operator import itemgetter
 
 import mmcv
@@ -79,6 +80,7 @@ def eval_hmean(results,
                img_infos,
                ann_infos,
                metrics={'hmean-iou'},
+               score_thr=None,
                min_score_thr=0.3,
                max_score_thr=0.9,
                step=0.1,
@@ -95,6 +97,7 @@ def eval_hmean(results,
             containing the following keys: filename, height, width
         ann_infos (list[dict]): Each dict corresponds to one image,
             containing the following keys: masks, masks_ignore
+        score_thr (float): Deprecated. Please use min_score_thr instead.
         min_score_thr (float): Minimum score threshold of prediction map.
         max_score_thr (float): Maximum score threshold of prediction map.
         step (float): The spacing between score thresholds.
@@ -106,6 +109,12 @@ def eval_hmean(results,
     assert utils.is_type_list(results, dict)
     assert utils.is_type_list(img_infos, dict)
     assert utils.is_type_list(ann_infos, dict)
+
+    if score_thr:
+        warnings.warn('score_thr is deprecated. Please use min_score_thr '
+                      'instead.')
+        min_score_thr = score_thr
+
     assert 0 <= min_score_thr <= max_score_thr <= 1
     assert 0 <= step <= 1
     assert len(results) == len(img_infos) == len(ann_infos)

--- a/mmocr/datasets/icdar_dataset.py
+++ b/mmocr/datasets/icdar_dataset.py
@@ -138,7 +138,9 @@ class IcdarDataset(CocoDataset):
                  results,
                  metric='hmean-iou',
                  logger=None,
-                 score_thr=0.3,
+                 min_score_thr=0.3,
+                 max_score_thr=0.9,
+                 step=0.1,
                  rank_list=None,
                  **kwargs):
         """Evaluate the hmean metric.
@@ -171,7 +173,9 @@ class IcdarDataset(CocoDataset):
             img_infos,
             ann_infos,
             metrics=metrics,
-            score_thr=score_thr,
+            min_score_thr=min_score_thr,
+            max_score_thr=max_score_thr,
+            step=step,
             logger=logger,
             rank_list=rank_list)
 

--- a/mmocr/datasets/icdar_dataset.py
+++ b/mmocr/datasets/icdar_dataset.py
@@ -138,6 +138,7 @@ class IcdarDataset(CocoDataset):
                  results,
                  metric='hmean-iou',
                  logger=None,
+                 score_thr=None,
                  min_score_thr=0.3,
                  max_score_thr=0.9,
                  step=0.1,
@@ -150,6 +151,10 @@ class IcdarDataset(CocoDataset):
             metric (str | list[str]): Metrics to be evaluated.
             logger (logging.Logger | str | None): Logger used for printing
                 related information during evaluation. Default: None.
+            score_thr (float): Deprecated. Please use min_score_thr instead.
+            min_score_thr (float): Minimum score threshold of prediction map.
+            max_score_thr (float): Maximum score threshold of prediction map.
+            step (float): The spacing between score thresholds.
             rank_list (str): json file used to save eval result
                 of each image after ranking.
         Returns:
@@ -173,6 +178,7 @@ class IcdarDataset(CocoDataset):
             img_infos,
             ann_infos,
             metrics=metrics,
+            score_thr=score_thr,
             min_score_thr=min_score_thr,
             max_score_thr=max_score_thr,
             step=step,

--- a/mmocr/datasets/text_det_dataset.py
+++ b/mmocr/datasets/text_det_dataset.py
@@ -80,7 +80,10 @@ class TextDetDataset(BaseDataset):
     def evaluate(self,
                  results,
                  metric='hmean-iou',
-                 score_thr=0.3,
+                 score_thr=None,
+                 min_score_thr=0.3,
+                 max_score_thr=0.9,
+                 step=0.1,
                  rank_list=None,
                  logger=None,
                  **kwargs):
@@ -89,7 +92,10 @@ class TextDetDataset(BaseDataset):
         Args:
             results (list): Testing results of the dataset.
             metric (str | list[str]): Metrics to be evaluated.
-            score_thr (float): Score threshold for prediction map.
+            score_thr (float): Deprecated. Please use min_score_thr instead.
+            min_score_thr (float): Minimum score threshold of prediction map.
+            max_score_thr (float): Maximum score threshold of prediction map.
+            step (float): The spacing between score thresholds.
             logger (logging.Logger | str | None): Logger used for printing
                 related information during evaluation. Default: None.
             rank_list (str): json file used to save eval result
@@ -116,6 +122,9 @@ class TextDetDataset(BaseDataset):
             ann_infos,
             metrics=metrics,
             score_thr=score_thr,
+            min_score_thr=min_score_thr,
+            max_score_thr=max_score_thr,
+            step=step,
             logger=logger,
             rank_list=rank_list)
 

--- a/tests/test_dataset/test_icdar_dataset.py
+++ b/tests/test_dataset/test_icdar_dataset.py
@@ -151,6 +151,21 @@ def test_icdar_dataset():
         'boundary_result': []
     }]
     output = dataset.evaluate(results, metrics)
-
     assert output['hmean-iou:hmean'] == 1
     assert output['hmean-ic13:hmean'] == 1
+
+    results = [{
+        'boundary_result': [[50, 60, 70, 60, 70, 80, 50, 80, 0.5],
+                            [100, 120, 130, 120, 120, 150, 100, 150, 1]]
+    }, {
+        'boundary_result': []
+    }]
+    output = dataset.evaluate(
+        results, metrics, min_score_thr=0, max_score_thr=1, step=0.5)
+    assert output['hmean-iou:hmean'] == 1
+    assert output['hmean-ic13:hmean'] == 1
+
+    output = dataset.evaluate(
+        results, metrics, min_score_thr=0.6, max_score_thr=1, step=0.5)
+    assert output['hmean-iou:hmean'] == 1 / 1.5
+    assert output['hmean-ic13:hmean'] == 1 / 1.5


### PR DESCRIPTION
## Motivation

The current implementation of `eval_hmean` only provides a parameter to set the minimum score with which the boundaries are used for evaluation. However, it always evaluates the filtered boundaries on a fixed set of threshold values `[0.3, 0,4, ..., 0.9]` no matter what the minimum score is, which is an inflexible and illogical design. There is also no entry in the config to customize such a behavior.

## Modification

This PR replaces `score_thr` with `min_score_thr, max_score_thr, step` so that users can configure the search space via input parameters. `IcdarDataset.evaluate()` is modified to allow these three parameters to be customized through the config file. 

For example, by adapting the following snippet in the config, one can evaluate the model's output on a list of boundary score thresholds `[0.1, 0.2, 0.3, 0.4, 0.5]` and get the best score from them.

```python
evaluation = dict(
    interval=100,
    metric='hmean-iou',
    min_score_thr=0.1,
    max_score_thr=0.5,
    step=0.1)
```

## BC-breaking (Optional)

None
