### PR TITLE
[Enhancement] Replace `opencv-python-headless` with `open-python`

### DIFF
--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -4,7 +4,7 @@ lmdb
 matplotlib
 numba>=0.45.1
 numpy
-opencv-python-headless<=4.5.4.60
+opencv-python
 pyclipper
 pycocotools
 rapidfuzz

--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -4,7 +4,7 @@ lmdb
 matplotlib
 numba>=0.45.1
 numpy
-opencv-python
+opencv-python<=4.5.4.60
 pyclipper
 pycocotools
 rapidfuzz


### PR DESCRIPTION
OpenCV has released 4.5.5.64, and this PR is intended to check if the issue in #694 still persists. Since `opencv-python-headless` does not have visualization utils which led to many issues from the community, this PR replaces this library with the full one to avoid any further confusion.

Update: 4.5.5.64 still not have it fixed yet.