### PR TITLE
[Feature] Support computing mean scores in UniformConcatDataset

### DIFF
--- a/mmocr/datasets/icdar_dataset.py
+++ b/mmocr/datasets/icdar_dataset.py
@@ -40,6 +40,9 @@ class IcdarDataset(CocoDataset):
         super().__init__(ann_file, pipeline, classes, data_root, img_prefix,
                          seg_prefix, proposal_file, test_mode, filter_empty_gt)
 
+        # Set dummy flags iust to be compatible with MMDet
+        self.flag = np.zeros(len(self), dtype=np.uint8)
+
     def load_annotations(self, ann_file):
         """Load annotation from COCO style annotation file.
 

--- a/mmocr/datasets/icdar_dataset.py
+++ b/mmocr/datasets/icdar_dataset.py
@@ -40,7 +40,7 @@ class IcdarDataset(CocoDataset):
         super().__init__(ann_file, pipeline, classes, data_root, img_prefix,
                          seg_prefix, proposal_file, test_mode, filter_empty_gt)
 
-        # Set dummy flags iust to be compatible with MMDet
+        # Set dummy flags just to be compatible with MMDet
         self.flag = np.zeros(len(self), dtype=np.uint8)
 
     def load_annotations(self, ann_file):

--- a/mmocr/datasets/uniform_concat_dataset.py
+++ b/mmocr/datasets/uniform_concat_dataset.py
@@ -63,6 +63,7 @@ class UniformConcatDataset(ConcatDataset):
             else:
                 new_datasets = datasets
         datasets = [build_dataset(c, kwargs) for c in new_datasets]
+        super().__init__(datasets, separate_eval)
 
         if not separate_eval:
             raise NotImplementedError(
@@ -75,7 +76,6 @@ class UniformConcatDataset(ConcatDataset):
                 raise NotImplementedError(
                     'To compute mean evaluation scores, all datasets'
                     'must have the same type')
-        super().__init__(datasets, separate_eval)
 
     @staticmethod
     def _apply_pipeline(datasets, pipeline, force_apply=False):

--- a/mmocr/datasets/uniform_concat_dataset.py
+++ b/mmocr/datasets/uniform_concat_dataset.py
@@ -19,6 +19,10 @@ class UniformConcatDataset(ConcatDataset):
         separate_eval (bool): Whether to evaluate the results
             separately if it is used as validation dataset.
             Defaults to True.
+        get_mean (bool): Whether to compute the mean evaluation results, only
+            applicable when ``separate_eval=True``. If ``True``, mean results
+            will be added to the result dictionary with keys in the form of
+            ``mean_{metric_name}``.
         pipeline (None | list[dict] | list[list[dict]]): If ``None``,
             each dataset in datasets use its own pipeline;
             If ``list[dict]``, it will be assigned to the dataset whose

--- a/tests/test_dataset/test_uniform_concat_dataset.py
+++ b/tests/test_dataset/test_uniform_concat_dataset.py
@@ -86,7 +86,7 @@ def test_uniform_concat_dataset_eval():
     assert results['0_n'] == 10
     assert results['1_n'] == 20
 
-    tmp_dataset = UniformConcatDataset(datasets, get_mean=True)
+    tmp_dataset = UniformConcatDataset(datasets, show_mean_scores=True)
     results = tmp_dataset.evaluate(fake_inputs)
     assert results['0_n'] == 10
     assert results['1_n'] == 20
@@ -114,4 +114,4 @@ def test_uniform_concat_dataset_eval():
         UniformConcatDataset(
             [dict(type='DummyDataset'),
              dict(type='DummyDataset2')],
-            get_mean=True)
+            show_mean_scores=True)

--- a/tests/test_dataset/test_uniform_concat_dataset.py
+++ b/tests/test_dataset/test_uniform_concat_dataset.py
@@ -1,11 +1,14 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 import copy
 
+import pytest
+from mmdet.datasets import DATASETS
+
 from mmocr.datasets import UniformConcatDataset
 from mmocr.utils import list_from_file
 
 
-def test_dataset_warpper():
+def test_uniform_concat_dataset_pipeline():
     pipeline1 = [dict(type='LoadImageFromFile')]
     pipeline2 = [dict(type='LoadImageFromFile'), dict(type='ColorJitter')]
 
@@ -58,3 +61,57 @@ def test_dataset_warpper():
         datasets=[[copy_train1], [copy_train2]],
         pipeline=[pipeline1, pipeline2])
     assert len(tmp_dataset.datasets[0].pipeline.transforms) == len(pipeline1)
+
+
+def test_uniform_concat_dataset_eval():
+
+    @DATASETS.register_module()
+    class DummyDataset:
+
+        def __init__(self):
+            self.CLASSES = 0
+            self.ann_file = 'empty'
+
+        def __len__(self):
+            return 1
+
+        def evaluate(self, res, logger, **kwargs):
+            return dict(n=res[0])
+
+    fake_inputs = [10, 20]
+    datasets = [dict(type='DummyDataset'), dict(type='DummyDataset')]
+
+    tmp_dataset = UniformConcatDataset(datasets)
+    results = tmp_dataset.evaluate(fake_inputs)
+    assert results['0_n'] == 10
+    assert results['1_n'] == 20
+
+    tmp_dataset = UniformConcatDataset(datasets, get_mean=True)
+    results = tmp_dataset.evaluate(fake_inputs)
+    assert results['0_n'] == 10
+    assert results['1_n'] == 20
+    assert results['mean_n'] == 15
+
+    with pytest.raises(NotImplementedError):
+        ds = UniformConcatDataset(datasets, separate_eval=False)
+        ds.evaluate(fake_inputs)
+
+    with pytest.raises(NotImplementedError):
+
+        @DATASETS.register_module()
+        class DummyDataset2:
+
+            def __init__(self):
+                self.CLASSES = 0
+                self.ann_file = 'empty'
+
+            def __len__(self):
+                return 1
+
+            def evaluate(self, res, logger, **kwargs):
+                return dict(n=res[0])
+
+        UniformConcatDataset(
+            [dict(type='DummyDataset'),
+             dict(type='DummyDataset2')],
+            get_mean=True)


### PR DESCRIPTION
## Motivation

Since text recognition models are usually evaluated on multiple datasets, it's hard to compare the model's performance across epochs without a unified indicator such as the mean scores. This PR supports `get_mean` in `UniformConcatDataset`. When it's on, the mean score of `{metric_name}` across concatenated datasets will be added to the evaluation results with the name `mean_{metric_name}`.

## Modification

Modified `mmdet.datasets.ConcatDataset.evaluate()` to compute the mean scores when both `self.separate_eval` and `self.get_mean` are True. Also disabled evaluating the datasets as a whole as this feature was not verified on MMOCR. We don't want to make excessive changes in this PR.

## BC-breaking (Optional)

No

## Todo

- [ ] Rename `get_mean` if we have a better suggestion
- [ ] Enable `get_mean` in all recog configs