### PR TITLE
[Enhancement] Allow choosing metrics to report in text recognition tasks

### DIFF
--- a/mmocr/core/evaluation/ocr_metric.py
+++ b/mmocr/core/evaluation/ocr_metric.py
@@ -4,6 +4,8 @@ from difflib import SequenceMatcher
 
 from rapidfuzz import string_metric
 
+from mmocr.utils import is_type_list
+
 
 def cal_true_positive_char(pred, gt):
     """Calculate correct character number in prediction.
@@ -81,52 +83,82 @@ def count_matches(pred_texts, gt_texts):
     return match_res
 
 
-def eval_ocr_metric(pred_texts, gt_texts):
+def eval_ocr_metric(pred_texts,
+                    gt_texts,
+                    metric=[
+                        'word_acc', 'word_acc_ignore_case',
+                        'word_acc_ignore_case_symbol', 'char_recall',
+                        'char_precision', 'one_minus_ned'
+                    ]):
     """Evaluate the text recognition performance with metric: word accuracy and
     1-N.E.D. See https://rrc.cvc.uab.es/?ch=14&com=tasks for details.
 
     Args:
         pred_texts (list[str]): Text strings of prediction.
         gt_texts (list[str]): Text strings of ground truth.
+        metric (str | list[str]): Metrics to be evaluated. Options are:
+
+          - 'word_acc': Accuracy in word level.
+          - 'word_acc_ignore_case': Accuracy in word level, ignoring letter
+            case.
+          - 'word_acc_ignore_case_symbol': Accuracy in word level, ignoring
+            letter case and symbol. (default metric for academic evaluation)
+          - 'char_recall': Recall in character level, ignore
+            letter case and symbol.
+          - 'char_precision': Precision in character level, ignore
+            letter case and symbol.
+          - 'one_minus_ned': 1 - normalized_edit_distance.
 
     Returns:
-        eval_res (dict[str: float]): Metric dict for text recognition, include:
-            - word_acc: Accuracy in word level.
-            - word_acc_ignore_case: Accuracy in word level, ignore letter case.
-            - word_acc_ignore_case_symbol: Accuracy in word level, ignore
-                letter case and symbol. (default metric for
-                academic evaluation)
-            - char_recall: Recall in character level, ignore
-                letter case and symbol.
-            - char_precision: Precision in character level, ignore
-                letter case and symbol.
-            - 1-N.E.D: 1 - normalized_edit_distance.
+        dict{str: float}: Result dict for text recognition, keys could be some
+        of the following: ['word_acc', 'word_acc_ignore_case',
+        'word_acc_ignore_case_symbol', 'char_recall', 'char_precision',
+        '1-N.E.D'].
     """
     assert isinstance(pred_texts, list)
     assert isinstance(gt_texts, list)
     assert len(pred_texts) == len(gt_texts)
+    assert isinstance(metric, str) or is_type_list(metric, str)
+    metric = set([metric]) if isinstance(metric, str) else set(metric)
+
+    supported_metrics = set([
+        'word_acc', 'word_acc_ignore_case', 'word_acc_ignore_case_symbol',
+        'char_recall', 'char_precision', 'one_minus_ned'
+    ])
+    assert metric.issubset(supported_metrics)
 
     match_res = count_matches(pred_texts, gt_texts)
     eps = 1e-8
-    char_recall = 1.0 * match_res['true_positive_char_num'] / (
-        eps + match_res['gt_char_num'])
-    char_precision = 1.0 * match_res['true_positive_char_num'] / (
-        eps + match_res['pred_char_num'])
-    word_acc = 1.0 * match_res['match_word_num'] / (
-        eps + match_res['gt_word_num'])
-    word_acc_ignore_case = 1.0 * match_res['match_word_ignore_case'] / (
-        eps + match_res['gt_word_num'])
-    word_acc_ignore_case_symbol = 1.0 * match_res[
-        'match_word_ignore_case_symbol'] / (
-            eps + match_res['gt_word_num'])
-
     eval_res = {}
-    eval_res['word_acc'] = word_acc
-    eval_res['word_acc_ignore_case'] = word_acc_ignore_case
-    eval_res['word_acc_ignore_case_symbol'] = word_acc_ignore_case_symbol
-    eval_res['char_recall'] = char_recall
-    eval_res['char_precision'] = char_precision
-    eval_res['1-N.E.D'] = 1.0 - match_res['ned']
+
+    if 'char_recall' in metric:
+        char_recall = 1.0 * match_res['true_positive_char_num'] / (
+            eps + match_res['gt_char_num'])
+        eval_res['char_recall'] = char_recall
+
+    if 'char_precision' in metric:
+        char_precision = 1.0 * match_res['true_positive_char_num'] / (
+            eps + match_res['pred_char_num'])
+        eval_res['char_precision'] = char_precision
+
+    if 'word_acc' in metric:
+        word_acc = 1.0 * match_res['match_word_num'] / (
+            eps + match_res['gt_word_num'])
+        eval_res['word_acc'] = word_acc
+
+    if 'word_acc_ignore_case' in metric:
+        word_acc_ignore_case = 1.0 * match_res['match_word_ignore_case'] / (
+            eps + match_res['gt_word_num'])
+        eval_res['word_acc_ignore_case'] = word_acc_ignore_case
+
+    if 'word_acc_ignore_case_symbol' in metric:
+        word_acc_ignore_case_symbol = 1.0 * match_res[
+            'match_word_ignore_case_symbol'] / (
+                eps + match_res['gt_word_num'])
+        eval_res['word_acc_ignore_case_symbol'] = word_acc_ignore_case_symbol
+
+    if 'one_minus_ned' in metric:
+        eval_res['1-N.E.D'] = 1.0 - match_res['ned']
 
     for key, value in eval_res.items():
         eval_res[key] = float('{:.4f}'.format(value))

--- a/mmocr/core/evaluation/ocr_metric.py
+++ b/mmocr/core/evaluation/ocr_metric.py
@@ -83,31 +83,28 @@ def count_matches(pred_texts, gt_texts):
     return match_res
 
 
-def eval_ocr_metric(pred_texts,
-                    gt_texts,
-                    metric=[
-                        'word_acc', 'word_acc_ignore_case',
-                        'word_acc_ignore_case_symbol', 'char_recall',
-                        'char_precision', 'one_minus_ned'
-                    ]):
+def eval_ocr_metric(pred_texts, gt_texts, metric='acc'):
     """Evaluate the text recognition performance with metric: word accuracy and
     1-N.E.D. See https://rrc.cvc.uab.es/?ch=14&com=tasks for details.
 
     Args:
         pred_texts (list[str]): Text strings of prediction.
         gt_texts (list[str]): Text strings of ground truth.
-        metric (str | list[str]): Metrics to be evaluated. Options are:
+        metric (str | list[str]): Metric(s) to be evaluated. Options are:
 
-          - 'word_acc': Accuracy in word level.
-          - 'word_acc_ignore_case': Accuracy in word level, ignoring letter
-            case.
-          - 'word_acc_ignore_case_symbol': Accuracy in word level, ignoring
-            letter case and symbol. (default metric for academic evaluation)
-          - 'char_recall': Recall in character level, ignore
-            letter case and symbol.
-          - 'char_precision': Precision in character level, ignore
-            letter case and symbol.
-          - 'one_minus_ned': 1 - normalized_edit_distance.
+            - 'word_acc': Accuracy in word level.
+            - 'word_acc_ignore_case': Accuracy in word level, ignoring letter
+              case.
+            - 'word_acc_ignore_case_symbol': Accuracy in word level, ignoring
+              letter case and symbol. (default metric for academic evaluation)
+            - 'char_recall': Recall in character level, ignore
+              letter case and symbol.
+            - 'char_precision': Precision in character level, ignore
+              letter case and symbol.
+            - 'one_minus_ned': 1 - normalized_edit_distance.
+
+            In particular, if ``metric == 'acc'``, results on all metrics above
+            will be reported.
 
     Returns:
         dict{str: float}: Result dict for text recognition, keys could be some
@@ -118,7 +115,13 @@ def eval_ocr_metric(pred_texts,
     assert isinstance(pred_texts, list)
     assert isinstance(gt_texts, list)
     assert len(pred_texts) == len(gt_texts)
+
     assert isinstance(metric, str) or is_type_list(metric, str)
+    if metric == 'acc' or metric == ['acc']:
+        metric = [
+            'word_acc', 'word_acc_ignore_case', 'word_acc_ignore_case_symbol',
+            'char_recall', 'char_precision', 'one_minus_ned'
+        ]
     metric = set([metric]) if isinstance(metric, str) else set(metric)
 
     supported_metrics = set([

--- a/mmocr/core/evaluation/ocr_metric.py
+++ b/mmocr/core/evaluation/ocr_metric.py
@@ -92,16 +92,16 @@ def eval_ocr_metric(pred_texts, gt_texts, metric='acc'):
         gt_texts (list[str]): Text strings of ground truth.
         metric (str | list[str]): Metric(s) to be evaluated. Options are:
 
-            - 'word_acc': Accuracy in word level.
-            - 'word_acc_ignore_case': Accuracy in word level, ignoring letter
+            - 'word_acc': Accuracy at word level.
+            - 'word_acc_ignore_case': Accuracy at word level, ignoring letter
               case.
-            - 'word_acc_ignore_case_symbol': Accuracy in word level, ignoring
-              letter case and symbol. (default metric for academic evaluation)
-            - 'char_recall': Recall in character level, ignore
+            - 'word_acc_ignore_case_symbol': Accuracy at word level, ignoring
+              letter case and symbol. (Default metric for academic evaluation)
+            - 'char_recall': Recall at character level, ignoring
               letter case and symbol.
-            - 'char_precision': Precision in character level, ignore
+            - 'char_precision': Precision at character level, ignoring
               letter case and symbol.
-            - 'one_minus_ned': 1 - normalized_edit_distance.
+            - 'one_minus_ned': 1 - normalized_edit_distance
 
             In particular, if ``metric == 'acc'``, results on all metrics above
             will be reported.

--- a/mmocr/datasets/ocr_dataset.py
+++ b/mmocr/datasets/ocr_dataset.py
@@ -3,6 +3,7 @@ from mmdet.datasets.builder import DATASETS
 
 from mmocr.core.evaluation.ocr_metric import eval_ocr_metric
 from mmocr.datasets.base_dataset import BaseDataset
+from mmocr.utils import is_type_list
 
 
 @DATASETS.register_module()
@@ -23,6 +24,8 @@ class OCRDataset(BaseDataset):
         Returns:
             dict[str: float]
         """
+        assert isinstance(metric, str) or is_type_list(metric, str)
+
         gt_texts = []
         pred_texts = []
         for i in range(len(self)):
@@ -31,6 +34,9 @@ class OCRDataset(BaseDataset):
             gt_texts.append(text)
             pred_texts.append(results[i]['text'])
 
-        eval_results = eval_ocr_metric(pred_texts, gt_texts)
+        if metric == 'acc':
+            eval_results = eval_ocr_metric(pred_texts, gt_texts)
+        else:
+            eval_results = eval_ocr_metric(pred_texts, gt_texts, metric=metric)
 
         return eval_results

--- a/mmocr/datasets/ocr_dataset.py
+++ b/mmocr/datasets/ocr_dataset.py
@@ -34,9 +34,6 @@ class OCRDataset(BaseDataset):
             gt_texts.append(text)
             pred_texts.append(results[i]['text'])
 
-        if metric == 'acc':
-            eval_results = eval_ocr_metric(pred_texts, gt_texts)
-        else:
-            eval_results = eval_ocr_metric(pred_texts, gt_texts, metric=metric)
+        eval_results = eval_ocr_metric(pred_texts, gt_texts, metric=metric)
 
         return eval_results

--- a/tests/test_dataset/test_ocr_dataset.py
+++ b/tests/test_dataset/test_ocr_dataset.py
@@ -50,3 +50,26 @@ def test_detect_dataset():
     assert math.isclose(eval_res['word_acc'], 0.5, abs_tol=1e-4)
     assert math.isclose(eval_res['char_precision'], 1.0, abs_tol=1e-4)
     assert math.isclose(eval_res['char_recall'], 0.9, abs_tol=1e-4)
+
+    eval_res = dataset.evaluate(results, metric='word_acc')
+    assert math.isclose(eval_res['word_acc'], 0.5, abs_tol=1e-4)
+    assert len(eval_res) == 1
+
+    eval_res = dataset.evaluate(
+        results, metric=['char_precision', 'char_recall'])
+    assert math.isclose(eval_res['char_precision'], 1.0, abs_tol=1e-4)
+    assert math.isclose(eval_res['char_recall'], 0.9, abs_tol=1e-4)
+    assert len(eval_res) == 2
+
+    results = [{'text': 'HELLO*'}, {'text': 'worl'}]
+    eval_res = dataset.evaluate(
+        results,
+        metric=[
+            'word_acc_ignore_case_symbol', 'word_acc_ignore_case',
+            'one_minus_ned'
+        ])
+    assert math.isclose(
+        eval_res['word_acc_ignore_case_symbol'], 0.5, abs_tol=1e-4)
+    assert math.isclose(eval_res['word_acc_ignore_case'], 0, abs_tol=1e-4)
+    assert math.isclose(eval_res['1-N.E.D'], 0.9, abs_tol=1e-4)
+    assert len(eval_res) == 3


### PR DESCRIPTION
## Motivation

Though MMOCR provides 6 evaluation metrics for text recognition tasks, there was no way to configure the metric(s) to evaluate the model, which usually results in an unnecessarily ong performance report. This PR enables the configuration entrance and users now can evaluate models on a subset of metrics selectively.

## Use Cases

Take the evaluation config in `configs/textrecog/crnn/crnn_academic_dataset.py` as an example. 

```python
evaluation = dict(interval=1, metric='acc')
```

The recognition metric `acc` is short for a collection of 6 metrics. One can expect a full performance report at the end of an evaluation cycle:

```python
{'0_char_recall': 0.0484, '0_char_precision': 0.6, '0_word_acc': 0.0, '0_word_acc_ignore_case': 0.0, '0_word_acc_ignore_case_symbol': 0.0, '0_1-N.E.D': 0.0525}
```

After this PR, one can specify a metric or a group of metrics to report in a way like:

```python
evaluation = dict(interval=1, metric=['word_acc_ignore_case', 'one_minus_ned'])
```

The result looks like:

```python
{'0_word_acc_ignore_case': 0.0, '0_1-N.E.D': 0.0525}
```

In testing, one can also specify the metrics to evaluate in the command line:

```bash
python tools/test.py configs/textrecog/crnn/crnn_toy_dataset.py crnn.pth --eval word_acc_ignore_case one_minus_ned
```

## BC-breaking:

None. We still hold the compatibility with `acc` metric for now.