### PR TITLE
[Fix] Fix lint_only in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,12 +20,12 @@ workflows:
           # line:
           # <regex path-to-test> <parameter-to-set> <value-of-pipeline-parameter>
           mapping: |
-            README.md lint_only true
-            README_zh-CN.md lint_only true
-            docs/.* lint_only true
-            demo/.* lint_only true
-            .dev_scripts/.* lint_only true
-            .github/workflows/.* lint_only true
+            mmocr/.* lint_only false
+            requirements/.* lint_only false
+            tests/.* lint_only false
+            tools/.* lint_only false
+            configs/.* lint_only false
+            .circleci/.* lint_only false
           base-revision: main
           # this is the path of the configuration we should trigger once
           # path filtering and pipeline parameter value updates are

--- a/.circleci/test.yml
+++ b/.circleci/test.yml
@@ -5,7 +5,7 @@ version: 2.1
 parameters:
   lint_only:
     type: boolean
-    default: false
+    default: true
 
 jobs:
   lint:


### PR DESCRIPTION
According to the current config, full tests are triggered when CircleCI does not detect the changes in a set of paths. However, it was logically wrong since if a commit changes both the docs and code, `lint_only` will still be true and no full tests would be performed. This PR flips the mapping around to ensure no undesired skips when the case above happens. 