### PR TITLE
[Fix] Remove unnecessary requirements

### DIFF
--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -2,12 +2,9 @@ imgaug
 lanms-neo==1.0.2
 lmdb
 matplotlib
-numba>=0.45.1
 numpy
 opencv-python<=4.5.4.60
 pyclipper
 pycocotools
 rapidfuzz
 scikit-image
-six
-terminaltables


### PR DESCRIPTION
Removing some "required" packages never used in MMOCR but causing trouble during installation on certain end devices.