### PR TITLE
[Docs] Configure Myst-parser to parse anchor tag

### DIFF
--- a/docs/en/conf.py
+++ b/docs/en/conf.py
@@ -124,6 +124,7 @@ html_css_files = ['css/readthedocs.css']
 
 # Enable ::: for my_st
 myst_enable_extensions = ['colon_fence']
+myst_heading_anchors = 3
 
 
 def builder_inited_handler(app):


### PR DESCRIPTION
By default, myst-parser did not parse links to anchor tags in markdown files, making these hyperlinks become raw texts in docs. This PR updates `myst`'s configuration to enable this feature.