### PR TITLE
simplify normalized edit distance calculation

### DIFF
--- a/mmocr/core/evaluation/ocr_metric.py
+++ b/mmocr/core/evaluation/ocr_metric.py
@@ -2,7 +2,7 @@
 import re
 from difflib import SequenceMatcher
 
-from rapidfuzz import string_metric
+from rapidfuzz.distance import Levenshtein
 
 from mmocr.utils import is_type_list
 
@@ -63,12 +63,8 @@ def count_matches(pred_texts, gt_texts):
             match_res['match_word_ignore_case_symbol'] += 1
         match_res['gt_word_num'] += 1
 
-        # normalized edit distance
-        edit_dist = string_metric.levenshtein(pred_text_lower_ignore,
-                                              gt_text_lower_ignore)
-        norm_ed = float(edit_dist) / max(1, len(gt_text_lower_ignore),
-                                         len(pred_text_lower_ignore))
-        norm_ed_sum += norm_ed
+        norm_ed_sum += Levenshtein.normalized_distance(pred_text_lower_ignore,
+                                                       gt_text_lower_ignore)
 
         # number to calculate char level recall & precision
         match_res['gt_char_num'] += len(gt_text_lower_ignore)

--- a/requirements/readthedocs.txt
+++ b/requirements/readthedocs.txt
@@ -6,7 +6,7 @@ matplotlib
 mmcv
 mmdet
 pyclipper
-rapidfuzz
+rapidfuzz>=2.0.0
 regex
 scikit-image
 scipy

--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -6,5 +6,5 @@ numpy
 opencv-python<=4.5.4.60
 pyclipper
 pycocotools
-rapidfuzz
+rapidfuzz>=2.0.0
 scikit-image


### PR DESCRIPTION
## Motivation

Replace usage of deprecated APIs and simplify implementation.

## Modification

The string_metric module in rapidfuzz is deprecated since v2.0.0 in addition the new module `rapidfuzz.distance.Levenshtein` provides a function to directly calculate the normalized Levenshtein distance. This can be used to simplify the implementation in mmocr.

## Checklist

**Before PR**:

- [x] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmocr/blob/main/.github/CONTRIBUTING.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmocr/blob/main/.github/CONTRIBUTING.md) are used to fix the potential lint issues.
- [x] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [x] If the modification has potential influence on downstream or other related projects, this PR should be tested with some of those projects.
- [x] CLA has been signed and all committers have signed the CLA in this PR.
