### PR TITLE
[Fix] Restrict the minimum version of OpenCV to avoid potential vulnerability

### DIFF
--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -3,7 +3,7 @@ lanms-neo==1.0.2
 lmdb
 matplotlib
 numpy
-opencv-python != 4.5.5.*
+opencv-python >=4.2.0.32, != 4.5.5.*  # avoid Github security alert
 pyclipper
 pycocotools
 rapidfuzz


### PR DESCRIPTION
There are around 30 known vulnerability issues if the minimum version of OpenCV has not been specified.

![image](https://user-images.githubusercontent.com/22607038/172787911-05356f9f-063d-4f95-b239-7706a0121a8b.png)

