### PR TITLE
Fixes missing schedule in the sample SEG training

### DIFF
--- a/configs/textrecog/seg/seg_r31_1by16_fpnocr_toy_dataset.py
+++ b/configs/textrecog/seg/seg_r31_1by16_fpnocr_toy_dataset.py
@@ -3,6 +3,7 @@ _base_ = [
     '../../_base_/recog_datasets/seg_toy_data.py',
     '../../_base_/recog_models/seg.py',
     '../../_base_/recog_pipelines/seg_pipeline.py',
+    '../../_base_/recog_datasets/academic_test.py'
 ]
 
 train_list = {{_base_.train_list}}


### PR DESCRIPTION

## Motivation

Running the command `python tools/train.py configs/textrecog/seg/seg_r31_1by16_fpnocr_toy_dataset.py --work-dir seg` from the "[Getting Started](https://mmocr.readthedocs.io/en/latest/getting_started.html#training-with-toy-dataset)" section leads to an issue with missing "checkpoint_config" parameter. This PR aims to fix this issue so that those doing the tutorial have a smoother experience.

## Modification

This PR adds a training schedule to the SEG toy dataset configuration, which allows to successfully execute the example training command.


## Checklist

**Before PR**:

- [x] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmocr/blob/main/.github/CONTRIBUTING.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmocr/blob/main/.github/CONTRIBUTING.md) are used to fix the potential lint issues.
- [ ] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with some of those projects.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
