### PR TITLE
Updating edge-embeddings after each GNN layer

### DIFF
--- a/mmocr/models/kie/heads/sdmgr_head.py
+++ b/mmocr/models/kie/heads/sdmgr_head.py
@@ -79,9 +79,9 @@ class SDMGRHead(BaseModule):
         embed_edges = F.normalize(embed_edges)
 
         for gnn_layer in self.gnn_layers:
-            nodes, cat_nodes = gnn_layer(nodes, embed_edges, node_nums)
+            nodes, embed_edges = gnn_layer(nodes, embed_edges, node_nums)
 
-        node_cls, edge_cls = self.node_cls(nodes), self.edge_cls(cat_nodes)
+        node_cls, edge_cls = self.node_cls(nodes), self.edge_cls(embed_edges)
         return node_cls, edge_cls
 
 


### PR DESCRIPTION
## Motivation

While understanding the SDMG-R model for Key Information Extraction, the forward pass seemed to be updating the edge embedding in the last layer of GNN. The item was discussed with the author https://github.com/open-mmlab/mmocr/issues/1122 to confirm and its fix

## Modification

For the KIE model, the edge embedding were not getting updated after every GNN layer in the model forward pass.




## Checklist

**Before PR**:

- [x] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmocr/blob/main/.github/CONTRIBUTING.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmocr/blob/main/.github/CONTRIBUTING.md) are used to fix the potential lint issues.
- [ ] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with some of those projects.
- [x] CLA has been signed and all committers have signed the CLA in this PR.
