### PR TITLE
bug fix: access params by cfg.get

### DIFF
--- a/tools/train.py
+++ b/tools/train.py
@@ -208,7 +208,7 @@ def main():
         else:
             val_dataset.pipeline = train_pipeline
         datasets.append(build_dataset(val_dataset))
-    if cfg.checkpoint_config is not None:
+    if cfg.get('checkpoint_config', None) is not None:
         # save mmdet version, config file content and class names in
         # checkpoints as meta data
         cfg.checkpoint_config.meta = dict(


### PR DESCRIPTION
cfg.get is better way to access the params when it may not exist.

## Motivation

According to #1140, I fix the config parameter access method.

## Modification

`cfg.checkpoint_config` raises error when it doesn't exist. `cfg.get("checkpoint_config", None)` is better. It's a least modification and won't affect other codes.

## BC-breaking (Optional)

NA

## Use cases (Optional)

NA

## Checklist

**Before PR**:

- [x] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmocr/blob/main/.github/CONTRIBUTING.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmocr/blob/main/.github/CONTRIBUTING.md) are used to fix the potential lint issues.
- [x] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with some of those projects.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
