### PR TITLE
fix typo of --lmdb-map-size default value

### DIFF
--- a/docs/en/tools.md
+++ b/docs/en/tools.md
@@ -33,7 +33,7 @@ Reading images or labels from files can be slow when data are excessive, e.g. on
 | `--label-format`  | str  | The format of the label file, either txt or jsonl.                 |
 | `--batch-size`    | int  | Processing batch size, defaults to 1000                            |
 | `--encoding`      | str  | Bytes coding scheme, defaults to utf8.                             |
-| `--lmdb-map-size` | int  | Maximum size database may grow to , defaults to 109951162776 bytes |
+| `--lmdb-map-size` | int  | Maximum size database may grow to , defaults to 1099511627776 bytes (1TB) |
 
 ### Examples
 

--- a/docs/en/tools.md
+++ b/docs/en/tools.md
@@ -24,15 +24,15 @@ The final output filename will be `psenet_r50_fpnf_sbn_1x_20190801-{hash id}.pth
 
 Reading images or labels from files can be slow when data are excessive, e.g. on a scale of millions. Besides, in academia, most of the scene text recognition datasets are stored in lmdb format, including images and labels. To get closer to the mainstream practice and enhance the data storage efficiency, MMOCR now provides `tools/data/utils/lmdb_converter.py` to convert text recognition datasets to lmdb format.
 
-| Arguments         | Type | Description                                                        |
-| ----------------- | ---- | ------------------------------------------------------------------ |
-| `label_path`      | str  | Path to label file.                                                |
-| `output`          | str  | Output lmdb path.                                                  |
-| `--img-root`      | str  | Input imglist path.                                                |
-| `--label-only`    | bool | Only converter label to lmdb                                       |
-| `--label-format`  | str  | The format of the label file, either txt or jsonl.                 |
-| `--batch-size`    | int  | Processing batch size, defaults to 1000                            |
-| `--encoding`      | str  | Bytes coding scheme, defaults to utf8.                             |
+| Arguments         | Type | Description                                                               |
+| ----------------- | ---- | ------------------------------------------------------------------------- |
+| `label_path`      | str  | Path to label file.                                                       |
+| `output`          | str  | Output lmdb path.                                                         |
+| `--img-root`      | str  | Input imglist path.                                                       |
+| `--label-only`    | bool | Only converter label to lmdb                                              |
+| `--label-format`  | str  | The format of the label file, either txt or jsonl.                        |
+| `--batch-size`    | int  | Processing batch size, defaults to 1000                                   |
+| `--encoding`      | str  | Bytes coding scheme, defaults to utf8.                                    |
 | `--lmdb-map-size` | int  | Maximum size database may grow to , defaults to 1099511627776 bytes (1TB) |
 
 ### Examples

--- a/mmocr/utils/lmdb_util.py
+++ b/mmocr/utils/lmdb_util.py
@@ -44,7 +44,7 @@ def recog2lmdb(img_root,
                label_only=False,
                batch_size=1000,
                encoding='utf-8',
-               lmdb_map_size=109951162776,
+               lmdb_map_size=1099511627776,
                verify=True):
     """Create text recognition dataset to LMDB format.
 

--- a/tools/data/utils/lmdb_converter.py
+++ b/tools/data/utils/lmdb_converter.py
@@ -36,9 +36,9 @@ def main():
         '--lmdb-map-size',
         '-m',
         type=int,
-        default=109951162776,
+        default=1099511627776,
         help='Maximum size database may grow to, '
-        'defaults to 109951162776 bytes')
+        'defaults to 1099511627776 bytes (1TB)')
     opt = parser.parse_args()
 
     assert opt.img_root or opt.label_only


### PR DESCRIPTION
## Motivation

Misleading default value of --lmdb-map-size. #1142 
109951162776 may refer to 1TB（1099511627776 in fact）, digit 7 left.

## Modification

Change default value from 109951162776 to 1099511627776 and add doc.
