### PR TITLE
[Fix] Update lmdb_converter and ct80 cropped image source in document

### DIFF
--- a/docs/en/datasets/recog.md
+++ b/docs/en/datasets/recog.md
@@ -209,13 +209,27 @@
 
 - Step1: Download [test_label.txt](https://download.openmmlab.com/mmocr/data/mixture/ct80/test_label.txt)
 
+- Step2: Download [timage.tar.gz](https://github.com/open-mmlab/mmocr/files/7408429/timage.tar.gz)
+
+- Step3:
+
+  ```bash
+  mkdir ct80 && cd ct80
+  mv /path/to/test_label.txt .
+  mv /path/to/timage.tar.gz .
+  tar -xvf timage.tar.gz
+  # create soft link
+  cd /path/to/mmocr/data/mixture
+  ln -s /path/to/ct80 ct80
+  ```
+
 - After running the above codes, the directory structure
   should be as follows:
 
   ```text
   ├── ct80
   │   ├── test_label.txt
-  │   └── image
+  │   └── timage
   ```
 
 ## svtp

--- a/docs/en/datasets/recog.md
+++ b/docs/en/datasets/recog.md
@@ -209,7 +209,7 @@
 
 - Step1: Download [test_label.txt](https://download.openmmlab.com/mmocr/data/mixture/ct80/test_label.txt)
 
-- Step2: Download [timage.tar.gz](https://github.com/open-mmlab/mmocr/files/7408429/timage.tar.gz)
+- Step2: Download [timage.tar.gz](https://download.openmmlab.com/mmocr/data/mixture/ct80/timage.tar.gz)
 
 - Step3:
 

--- a/docs/en/datasets/recog.md
+++ b/docs/en/datasets/recog.md
@@ -274,7 +274,7 @@ Please make sure you're using the right annotation to train the model by checkin
 
   # Convert 'txt' format annos to 'lmdb' (optional)
   cd /path/to/mmocr
-  python tools/data/utils/txt2lmdb.py -i data/mixture/Syn90k/label.txt -o data/mixture/Syn90k/label.lmdb
+  python tools/data/utils/lmdb_converter.py data/mixture/Syn90k/label.txt data/mixture/Syn90k/label.lmdb --label-only
   ```
 
 - After running the above codes, the directory structure
@@ -325,7 +325,7 @@ Please make sure you're using the right annotation to train the model by checkin
 
   # Convert 'txt' format annos to 'lmdb' (optional)
   cd /path/to/mmocr
-  python tools/data/utils/txt2lmdb.py -i data/mixture/SynthText/label.txt -o data/mixture/SynthText/label.lmdb
+  python tools/data/utils/lmdb_converter.py data/mixture/SynthText/label.txt data/mixture/SynthText/label.lmdb --label-only
   ```
 
 - After running the above codes, the directory structure
@@ -365,7 +365,7 @@ Please make sure you're using the right annotation to train the model by checkin
 
   # Convert 'txt' format annos to 'lmdb' (optional)
   cd /path/to/mmocr
-  python tools/data/utils/txt2lmdb.py -i data/mixture/SynthAdd/label.txt -o data/mixture/SynthAdd/label.lmdb
+  python tools/data/utils/lmdb_converter.py data/mixture/SynthAdd/label.txt data/mixture/SynthAdd/label.lmdb --label-only
   ```
 
 - After running the above codes, the directory structure
@@ -382,13 +382,13 @@ Please make sure you're using the right annotation to train the model by checkin
 To convert label file from `txt` format to `lmdb` format,
 
 ```bash
-python tools/data/utils/txt2lmdb.py -i <txt_label_path> -o <lmdb_label_path>
+python tools/data/utils/lmdb_converter.py <txt_label_path> <lmdb_label_path> --label-only
 ```
 
 For example,
 
 ```bash
-python tools/data/utils/txt2lmdb.py -i data/mixture/Syn90k/label.txt -o data/mixture/Syn90k/label.lmdb
+python tools/data/utils/lmdb_converter.py data/mixture/Syn90k/label.txt data/mixture/Syn90k/label.lmdb --label-only
 ```
 
 ````


### PR DESCRIPTION
Update lmdb_converter and ct80 cropped data source

## Motivation

1. `tools/data/utils/txt2lmdb.py` is replaced with `lmdb_converter.py` but didn't update in the document (resolve #1088)
2. ct80 labels are for cropped images while didn't provide the cropped data source in the document (resolve #536).

## Modification

1. replace `txt2lmdb.py` with `lmdb_converter.py` with the correct usage.
2. update the data preparation for ct80, data source from [gaotongxiao's answer](https://github.com/open-mmlab/mmocr/issues/536#issuecomment-950658357)

## Checklist

**Before PR**:

- [x] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmocr/blob/main/.github/CONTRIBUTING.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmocr/blob/main/.github/CONTRIBUTING.md) are used to fix the potential lint issues.
- [x] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with some of those projects.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
