### PR TITLE
[Fix] Fix mobilenet init

### DIFF
--- a/mmocr/models/textrecog/backbones/mobilenet_v2.py
+++ b/mmocr/models/textrecog/backbones/mobilenet_v2.py
@@ -6,6 +6,7 @@ from mmdet.models.backbones import MobileNetV2 as MMDet_MobileNetV2
 from torch import Tensor
 
 from mmocr.registry import MODELS
+from mmocr.utils.typing import InitConfigType
 
 
 @MODELS.register_module()
@@ -14,6 +15,7 @@ class MobileNetV2(MMDet_MobileNetV2):
 
     Args:
         pooling_layers (list): List of indices of pooling layers.
+        init_cfg (InitConfigType, optional): Initialization config dict.
     """
     # Parameters to build layers. 4 parameters are needed to construct a
     # layer, from left to right: expand_ratio, channel, num_blocks, stride.
@@ -21,8 +23,10 @@ class MobileNetV2(MMDet_MobileNetV2):
                      [6, 64, 4, 1], [6, 96, 3, 1], [6, 160, 3, 1],
                      [6, 320, 1, 1]]
 
-    def __init__(self, pooling_layers: List = [3, 4, 5]) -> None:
-        super().__init__()
+    def __init__(self,
+                 pooling_layers: List = [3, 4, 5],
+                 init_cfg: InitConfigType = None) -> None:
+        super().__init__(init_cfg=init_cfg)
         self.pooling = nn.MaxPool2d((2, 2), (2, 1), (0, 1))
         self.pooling_layers = pooling_layers
 


### PR DESCRIPTION
It was missed to add `init_cfg` in mobilenet backbone, which caused an error at inference.