### PR TITLE
[Fix] Fix LMDB dataset

### DIFF
--- a/mmocr/datasets/recog_lmdb_dataset.py
+++ b/mmocr/datasets/recog_lmdb_dataset.py
@@ -162,7 +162,7 @@ class RecogLMDBDataset(BaseDataset):
         """
         data_info = {}
         parsed_anno = self.parser(raw_anno_info)
-        if self.label_only and not self.deprecated_format:
+        if self.label_only or self.deprecated_format:
             img_path = osp.join(self.data_prefix['img_path'],
                                 parsed_anno[self.parser.keys[0]])
         else:

--- a/mmocr/datasets/recog_lmdb_dataset.py
+++ b/mmocr/datasets/recog_lmdb_dataset.py
@@ -5,6 +5,7 @@ import warnings
 from typing import Callable, List, Optional, Sequence, Union
 
 from mmengine.dataset import BaseDataset
+from mmengine.utils import is_abs
 
 from mmocr.registry import DATASETS, TASK_UTILS
 
@@ -180,8 +181,10 @@ class RecogLMDBDataset(BaseDataset):
         except ImportError:
             raise ImportError(
                 'Please install lmdb to enable RecogLMDBDataset.')
+        lmdb_path = self.ann_file if is_abs(self.ann_file) else osp.join(
+            root, self.ann_file)
         return lmdb.open(
-            osp.join(root, self.ann_file),
+            lmdb_path,
             max_readers=1,
             readonly=True,
             lock=False,

--- a/mmocr/datasets/recog_lmdb_dataset.py
+++ b/mmocr/datasets/recog_lmdb_dataset.py
@@ -162,11 +162,8 @@ class RecogLMDBDataset(BaseDataset):
         """
         data_info = {}
         parsed_anno = self.parser(raw_anno_info)
-        if self.label_only or self.deprecated_format:
-            img_path = osp.join(self.data_prefix['img_path'],
-                                parsed_anno[self.parser.keys[0]])
-        else:
-            img_path = parsed_anno[self.parser.keys[0]]
+        img_path = osp.join(self.data_prefix['img_path'],
+                            parsed_anno[self.parser.keys[0]])
 
         data_info['img_path'] = img_path
         data_info['instances'] = [dict(text=parsed_anno[self.parser.keys[1]])]


### PR DESCRIPTION
This PR fixes：

1. `super().__init__()` will concat `self.ann_file` and `self.data_root`, however, the first `_get_env()` will be called before `super().__init__()`, hence, the `ann_file` cannot be found if it is not an absolute path. And this issue cannot be solved by simply move the `super().__init__()` to the beginning of `init()`, because the `super().__init()__` relies on `self.total_number` which is obtained by `_get_env()`. Therefore, this PR adds a `root` arg to help the `_get_env()` to get the correct path in `init()`.
