### PR TITLE
add if condition to visualize the kie output only when the output argument is supplied

### DIFF
--- a/mmocr/utils/ocr.py
+++ b/mmocr/utils/ocr.py
@@ -764,13 +764,14 @@ class MMOCR:
                     ann=ann_info,
                     return_data=True,
                     batch_mode=self.args.batch_mode)
-                # visualize KIE results
-                self.visualize_kie_output(
-                    kie_model,
-                    data,
-                    kie_result,
-                    out_file=out_file,
-                    show=self.args.imshow)
+                # visualize KIE results if argument output is True
+                if self.args.output:
+                    self.visualize_kie_output(
+                        kie_model,
+                        data,
+                        kie_result,
+                        out_file=out_file,
+                        show=self.args.imshow)
                 gt_bboxes = data['gt_bboxes'].data.numpy().tolist()
                 labels = self.generate_kie_labels(kie_result, gt_bboxes,
                                                   kie_model.class_list)


### PR DESCRIPTION
## Motivation

Improve the MMOCR package.

## Modification

this prevents ImageFont OSError: unknown file format in production, when visualization is not required, as well as saves resources producing more efficient functionality to when required.

## BC-breaking (Optional)

MINOR logical update

## Use cases (Optional)

--output argument should be supplied to get the visualized KIE output
