### PR TITLE
When '.' char not in output string, output is also considered to be a…

### DIFF
--- a/mmocr/utils/ocr.py
+++ b/mmocr/utils/ocr.py
@@ -841,7 +841,7 @@ class MMOCR:
         num_res = len(img_list)
         if args.output:
             output_path = Path(args.output)
-            if output_path.is_dir():
+            if output_path.is_dir() or '.' not in args.output:
                 args.output = [
                     str(output_path / f'out_{x}.png') for x in args.filenames
                 ]


### PR DESCRIPTION
… folder


## Motivation

In my case, 'demo' is a folder containing multiple images, and 'demo_res' is the folder where I want the program prediction results to be saved, which has not been created yet. When I use the following code, the program executes as expected.

```
from mmocr.utils.ocr import MMOCR
ocr = MMOCR(det='TextSnake', recog=None)
results = ocr.readtext('demo/', output='demo_res/', export='demo_res/')
```

**Note that the demo_res folder has not been created before the above program is executed.**
The program will automatically create the 'demo_res' folder for me, thanks to the related logic of 'export'.

So I modified the above program slightly.

```
from mmocr.utils.ocr import MMOCR
ocr = MMOCR(det='TextSnake', recog=None)
results = ocr.readtext('demo/', output='demo_output_res/', export='demo_res/')
```
**Note that 'demo_output_res' and 'demo_res' folders have not been created yet.**

Then the program throws the following exception.

`cv2.error: OpenCV(4.4.0) C:\Users\appveyor\AppData\Local\Temp\1\pip-req-build-h4wtvo23\opencv\modules\imgcodecs\src\loadsave.cpp:926: error: (-2:Unspecified error) could not find encoder for the specified extension in function 'cv::imencode'`

**Because the program treats the uncreated folder as a file and tries to write the file with opencv, and requires a specific file extension.**

So I think files without file extension should be treated as folders in this program. Moreover, regardless of whether 'output' is a file or not, when it has no file extension, an exception will be throw in this program.

## Modification

When the file extension identifies '.' does not exist, the file is considered to be a folder



