### PR TITLE
[Feature] support modified resnet structure used in oCLIP

### DIFF
--- a/mmocr/models/common/backbones/__init__.py
+++ b/mmocr/models/common/backbones/__init__.py
@@ -1,4 +1,5 @@
 # Copyright (c) OpenMMLab. All rights reserved.
+from .clip_resnet import CLIPResNet
 from .unet import UNet
 
-__all__ = ['UNet']
+__all__ = ['UNet', 'CLIPResNet']

--- a/mmocr/models/common/backbones/clip_resnet.py
+++ b/mmocr/models/common/backbones/clip_resnet.py
@@ -39,8 +39,7 @@ class CLIPBottleneck(Bottleneck):
 
 @MODELS.register_module()
 class CLIPResNet(ResNet):
-    """Implement the ResNet variant used in `oCLIP.
-
+    """Implement the ResNet variant used in `oCLIP
     <https://github.com/bytedance/oclip>`_.
 
     It is also the official structure in
@@ -57,13 +56,13 @@ class CLIPResNet(ResNet):
     The stride of each convolution layer is always set to 1.
 
     Args:
-        depth (int): Depth of resnet, from {50}. Defaults to 50.
+        depth (int): Depth of resnet, options are [50]. Defaults to 50.
         strides (sequence(int)): Strides of the first block of each stage.
             Defaults to (1, 2, 2, 2).
         deep_stem (bool): Replace 7x7 conv in input stem with 3 3x3 conv.
             Defaults to True.
-        avg_down (bool): Use AvgPool instead of stride conv when
-            downsampling in the bottleneck. Defaults to True.
+        avg_down (bool): Use AvgPool instead of stride conv at
+            the downsampling stage in the bottleneck. Defaults to True.
         **kwargs: Keyword arguments for
             :class:``mmdet.models.backbones.resnet.ResNet``.
     """
@@ -84,7 +83,7 @@ class CLIPResNet(ResNet):
             avg_down=avg_down,
             **kwargs)
 
-    def _make_stem_layer(self, in_channels, stem_channels):
+    def _make_stem_layer(self, in_channels: int, stem_channels: int):
         """Build stem layer for CLIPResNet used in `CLIP
         https://github.com/openai/CLIP>`_.
 

--- a/mmocr/models/common/backbones/clip_resnet.py
+++ b/mmocr/models/common/backbones/clip_resnet.py
@@ -10,10 +10,14 @@ from mmocr.registry import MODELS
 class CLIPBottleneck(Bottleneck):
     """Bottleneck for CLIPResNet.
 
-    It is a variant Bottleneck used in the variant ResNet of CLIP. After the
+    It is a Bottleneck variant used in the ResNet variant of CLIP. After the
     second convolution layer, there is an additional average pooling layer with
-    kernel_size 2 and stride 2, which is added in the plug-in manner when the
+    kernel_size 2 and stride 2, which is added as a plugin when the
     input stride > 1. The stride of each convolution layer is always set to 1.
+
+    Args:
+        **kwargs: Keyword arguments for
+            :class:``mmdet.models.backbones.resnet.Bottleneck``.
     """
 
     def __init__(self, **kwargs):
@@ -35,12 +39,12 @@ class CLIPBottleneck(Bottleneck):
 
 @MODELS.register_module()
 class CLIPResNet(ResNet):
-    """Implement the variant ResNet used in `oCLIP.
+    """Implement the ResNet variant used in `oCLIP.
 
-    <https://github.com/bytedance/oclip>`_
+    <https://github.com/bytedance/oclip>`_.
 
-    It is also the official structure in `CLIP
-    <https://github.com/openai/CLIP>`_.
+    It is also the official structure in
+    `CLIP <https://github.com/openai/CLIP>`_.
 
     Compared with ResNetV1d structure, CLIPResNet replaces the
     max pooling layer with an average pooling layer at the end
@@ -48,9 +52,20 @@ class CLIPResNet(ResNet):
 
     In the Bottleneck of CLIPResNet, after the second convolution
     layer, there is an additional average pooling layer with
-    kernel_size 2 and stride 2, which is added in the plug-in
-    manner when the input stride > 1.
+    kernel_size 2 and stride 2, which is added as a plugin
+    when the input stride > 1.
     The stride of each convolution layer is always set to 1.
+
+    Args:
+        depth (int): Depth of resnet, from {50}. Defaults to 50.
+        strides (sequence(int)): Strides of the first block of each stage.
+            Defaults to (1, 2, 2, 2).
+        deep_stem (bool): Replace 7x7 conv in input stem with 3 3x3 conv.
+            Defaults to True.
+        avg_down (bool): Use AvgPool instead of stride conv when
+            downsampling in the bottleneck. Defaults to True.
+        **kwargs: Keyword arguments for
+            :class:``mmdet.models.backbones.resnet.ResNet``.
     """
     arch_settings = {
         50: (CLIPBottleneck, (3, 4, 6, 3)),
@@ -70,9 +85,9 @@ class CLIPResNet(ResNet):
             **kwargs)
 
     def _make_stem_layer(self, in_channels, stem_channels):
-        """Build stem layer for CLIPResNet used in `CLIP.
+        """Build stem layer for CLIPResNet used in `CLIP
+        https://github.com/openai/CLIP>`_.
 
-        <https://github.com/openai/CLIP>`_.
         It uses an average pooling layer rather than a max pooling
         layer at the end of the input stem.
 

--- a/mmocr/models/common/backbones/clip_resnet.py
+++ b/mmocr/models/common/backbones/clip_resnet.py
@@ -1,0 +1,85 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+
+import torch.nn as nn
+from mmdet.models.backbones import ResNet
+from mmdet.models.backbones.resnet import Bottleneck
+
+from mmocr.registry import MODELS
+
+
+class CLIPBottleneck(Bottleneck):
+    """Bottleneck for CLIPResNet.
+
+    It is a variant Bottleneck used in the variant ResNet of CLIP. After the
+    second convolution layer, there is an additional average pooling layer with
+    kernel_size 2 and stride 2, which is added in the plug-in manner when the
+    input stride > 1. The stride of each convolution layer is always set to 1.
+    """
+
+    def __init__(self, **kwargs):
+        stride = kwargs.get('stride', 1)
+        kwargs['stride'] = 1
+        plugins = kwargs.get('plugins', None)
+        if stride > 1:
+            if plugins is None:
+                plugins = []
+
+            plugins.insert(
+                0,
+                dict(
+                    cfg=dict(type='mmocr.AvgPool2d', kernel_size=2),
+                    position='after_conv2'))
+            kwargs['plugins'] = plugins
+        super().__init__(**kwargs)
+
+
+@MODELS.register_module()
+class CLIPResNet(ResNet):
+    """Implement the variant ResNet used in `oCLIP.
+
+    <https://github.com/bytedance/oclip>`_
+
+    It is also the official structure in `CLIP
+    <https://github.com/openai/CLIP>`_.
+
+    Compared with ResNetV1d structure, CLIPResNet replaces the
+    max pooling layer with an average pooling layer at the end
+    of the input stem.
+
+    In the Bottleneck of CLIPResNet, after the second convolution
+    layer, there is an additional average pooling layer with
+    kernel_size 2 and stride 2, which is added in the plug-in
+    manner when the input stride > 1.
+    The stride of each convolution layer is always set to 1.
+    """
+    arch_settings = {
+        50: (CLIPBottleneck, (3, 4, 6, 3)),
+    }
+
+    def __init__(self,
+                 depth=50,
+                 strides=(1, 2, 2, 2),
+                 deep_stem=True,
+                 avg_down=True,
+                 **kwargs):
+        super().__init__(
+            depth=depth,
+            strides=strides,
+            deep_stem=deep_stem,
+            avg_down=avg_down,
+            **kwargs)
+
+    def _make_stem_layer(self, in_channels, stem_channels):
+        """Build stem layer for CLIPResNet used in `CLIP.
+
+        <https://github.com/openai/CLIP>`_.
+        It uses an average pooling layer rather than a max pooling
+        layer at the end of the input stem.
+
+        Args:
+            in_channels (int): Number of input channels.
+            stem_channels (int): Number of output channels.
+        """
+        super()._make_stem_layer(in_channels, stem_channels)
+        if self.deep_stem:
+            self.maxpool = nn.AvgPool2d(kernel_size=2)

--- a/mmocr/models/common/backbones/clip_resnet.py
+++ b/mmocr/models/common/backbones/clip_resnet.py
@@ -39,7 +39,8 @@ class CLIPBottleneck(Bottleneck):
 
 @MODELS.register_module()
 class CLIPResNet(ResNet):
-    """Implement the ResNet variant used in `oCLIP
+    """Implement the ResNet variant used in `oCLIP.
+
     <https://github.com/bytedance/oclip>`_.
 
     It is also the official structure in

--- a/mmocr/models/common/plugins/__init__.py
+++ b/mmocr/models/common/plugins/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+from .common import AvgPool2d
+
+__all__ = ['AvgPool2d']

--- a/mmocr/models/common/plugins/common.py
+++ b/mmocr/models/common/plugins/common.py
@@ -1,5 +1,5 @@
 # Copyright (c) OpenMMLab. All rights reserved.
-from typing import Tuple, Union
+from typing import Optional, Tuple, Union
 
 import torch
 import torch.nn as nn
@@ -12,17 +12,18 @@ class AvgPool2d(nn.Module):
     """Applies a 2D average pooling over an input signal composed of several
     input planes.
 
-    AvgPool2d class for plug-in manner usage
+    It can also be used as a network plugin.
 
     Args:
-        kernel_size (int | tuple(int)): the size of the window.
-        stride (int | tuple(int)): the stride of the window.
-        padding (int | tuple(int)): implicit zero padding.
+        kernel_size (int or tuple(int)): the size of the window.
+        stride (int or tuple(int), optional): the stride of the window.
+            Defaults to None.
+        padding (int or tuple(int)): implicit zero padding. Defaults to 0.
     """
 
     def __init__(self,
                  kernel_size: Union[int, Tuple[int]],
-                 stride: Union[int, Tuple[int]] = None,
+                 stride: Optional[Union[int, Tuple[int]]] = None,
                  padding: Union[int, Tuple[int]] = 0,
                  **kwargs) -> None:
         super().__init__()
@@ -34,6 +35,6 @@ class AvgPool2d(nn.Module):
             x (Tensor): Input feature map.
 
         Returns:
-            Tensor: Output tensor after Maxpooling layer.
+            Tensor: Output tensor after Avgpooling layer.
         """
         return self.model(x)

--- a/mmocr/models/common/plugins/common.py
+++ b/mmocr/models/common/plugins/common.py
@@ -1,0 +1,39 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+from typing import Tuple, Union
+
+import torch
+import torch.nn as nn
+
+from mmocr.registry import MODELS
+
+
+@MODELS.register_module()
+class AvgPool2d(nn.Module):
+    """Applies a 2D average pooling over an input signal composed of several
+    input planes.
+
+    AvgPool2d class for plug-in manner usage
+
+    Args:
+        kernel_size (int | tuple(int)): the size of the window.
+        stride (int | tuple(int)): the stride of the window.
+        padding (int | tuple(int)): implicit zero padding.
+    """
+
+    def __init__(self,
+                 kernel_size: Union[int, Tuple[int]],
+                 stride: Union[int, Tuple[int]] = None,
+                 padding: Union[int, Tuple[int]] = 0,
+                 **kwargs) -> None:
+        super().__init__()
+        self.model = nn.AvgPool2d(kernel_size, stride, padding)
+
+    def forward(self, x) -> torch.Tensor:
+        """Forward function.
+        Args:
+            x (Tensor): Input feature map.
+
+        Returns:
+            Tensor: Output tensor after Maxpooling layer.
+        """
+        return self.model(x)

--- a/mmocr/models/common/plugins/common.py
+++ b/mmocr/models/common/plugins/common.py
@@ -29,7 +29,7 @@ class AvgPool2d(nn.Module):
         super().__init__()
         self.model = nn.AvgPool2d(kernel_size, stride, padding)
 
-    def forward(self, x) -> torch.Tensor:
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
         """Forward function.
         Args:
             x (Tensor): Input feature map.

--- a/tests/test_models/test_common/test_backbones/test_clip_resnet.py
+++ b/tests/test_models/test_common/test_backbones/test_clip_resnet.py
@@ -1,0 +1,66 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+from unittest import TestCase
+
+import torch
+import torch.nn as nn
+from mmcv.cnn import build_conv_layer, build_norm_layer
+
+from mmocr.models.common.backbones import CLIPResNet
+from mmocr.models.common.backbones.clip_resnet import CLIPBottleneck
+
+
+class TestCLIPResNet(TestCase):
+
+    def test_forward(self):
+        model = CLIPResNet()
+        model.eval()
+
+        imgs = torch.randn(1, 3, 32, 32)
+        feat = model(imgs)
+        assert len(feat) == 4
+        assert feat[0].shape == torch.Size([1, 256, 8, 8])
+        assert feat[1].shape == torch.Size([1, 512, 4, 4])
+        assert feat[2].shape == torch.Size([1, 1024, 2, 2])
+        assert feat[3].shape == torch.Size([1, 2048, 1, 1])
+
+
+class TestCLIPBottleneck(TestCase):
+
+    def test_forward(self):
+        stride = 1
+        inplanes = 64
+        planes = 64
+        conv_cfg = None
+        norm_cfg = {'type': 'BN', 'requires_grad': True}
+
+        downsample = []
+        downsample.append(
+            nn.AvgPool2d(
+                kernel_size=stride,
+                stride=stride,
+                ceil_mode=True,
+                count_include_pad=False))
+        downsample.extend([
+            build_conv_layer(
+                conv_cfg,
+                inplanes,
+                planes * CLIPBottleneck.expansion,
+                kernel_size=1,
+                stride=stride,
+                bias=False),
+            build_norm_layer(norm_cfg, planes * CLIPBottleneck.expansion)[1]
+        ])
+        downsample = nn.Sequential(*downsample)
+
+        model = CLIPBottleneck(
+            inplanes=64,
+            planes=64,
+            stride=stride,
+            downsample=downsample,
+            conv_cfg=conv_cfg,
+            norm_cfg=norm_cfg)
+        model.eval()
+
+        input_feat = torch.randn(1, 64, 8, 8)
+        output_feat = model(input_feat)
+        assert output_feat.shape == torch.Size([1, 256, 8, 8])

--- a/tests/test_models/test_common/test_backbones/test_clip_resnet.py
+++ b/tests/test_models/test_common/test_backbones/test_clip_resnet.py
@@ -27,9 +27,9 @@ class TestCLIPResNet(TestCase):
 class TestCLIPBottleneck(TestCase):
 
     def test_forward(self):
-        stride = 1
-        inplanes = 64
-        planes = 64
+        stride = 2
+        inplanes = 256
+        planes = 128
         conv_cfg = None
         norm_cfg = {'type': 'BN', 'requires_grad': True}
 
@@ -46,21 +46,21 @@ class TestCLIPBottleneck(TestCase):
                 inplanes,
                 planes * CLIPBottleneck.expansion,
                 kernel_size=1,
-                stride=stride,
+                stride=1,
                 bias=False),
             build_norm_layer(norm_cfg, planes * CLIPBottleneck.expansion)[1]
         ])
         downsample = nn.Sequential(*downsample)
 
         model = CLIPBottleneck(
-            inplanes=64,
-            planes=64,
+            inplanes=inplanes,
+            planes=planes,
             stride=stride,
             downsample=downsample,
             conv_cfg=conv_cfg,
             norm_cfg=norm_cfg)
         model.eval()
 
-        input_feat = torch.randn(1, 64, 8, 8)
+        input_feat = torch.randn(1, 256, 8, 8)
         output_feat = model(input_feat)
-        assert output_feat.shape == torch.Size([1, 256, 8, 8])
+        assert output_feat.shape == torch.Size([1, 512, 4, 4])

--- a/tests/test_models/test_common/test_plugins/test_avgpool.py
+++ b/tests/test_models/test_common/test_plugins/test_avgpool.py
@@ -1,0 +1,16 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+from unittest import TestCase
+
+import torch
+
+from mmocr.models.common.plugins import AvgPool2d
+
+
+class TestAvgPool2d(TestCase):
+
+    def setUp(self) -> None:
+        self.img = torch.rand(1, 3, 32, 100)
+
+    def test_avgpool2d(self):
+        avgpool2d = AvgPool2d(kernel_size=2, stride=2)
+        self.assertEqual(avgpool2d(self.img).shape, torch.Size([1, 3, 16, 50]))


### PR DESCRIPTION
## Motivation
To support modified resnet structure used in [oCLIP](https://github.com/bytedance/oclip), which is also the official structure in [CLIP](https://github.com/openai/CLIP).
Currently, I only implement CLIPResNet-50 when depth=50. CLIPResNet-101 would be implemented later.
We also provide a [script](https://github.com/bytedance/oclip/blob/main/tools/convert2mmocr.py) for converting the parameter names of our models to MMOCR style.

For more information, please refer to [oCLIP](https://github.com/bytedance/oclip)

## Modification

Add a new ResNet structure, named as CLIPResNet in mmocr/models/common/backbones/clip_resnet.py

## Checklist

**Before PR**:

- [x] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmocr/blob/main/.github/CONTRIBUTING.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmocr/blob/main/.github/CONTRIBUTING.md) are used to fix the potential lint issues.
- [x] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with some of those projects.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
