### PR TITLE
Convert numpy.float32 type to python built-in float type

### DIFF
--- a/mmocr/models/textdet/postprocess/pse_postprocessor.py
+++ b/mmocr/models/textdet/postprocess/pse_postprocessor.py
@@ -74,7 +74,7 @@ class PSEPostprocessor(BasePostprocessor):
         for i in range(1, label_num + 1):
             points = np.array(np.where(labels == i)).transpose((1, 0))[:, ::-1]
             area = points.shape[0]
-            score_instance = np.mean(score[labels == i])
+            score_instance = np.mean(score[labels == i]).item()
             if not self.is_valid_instance(area, score_instance,
                                           self.min_text_area,
                                           self.min_text_avg_confidence):


### PR DESCRIPTION

## Motivation

When I follow the documentation to convert the psenet model to torchserve model and start the torchserve service, the predicted image will receive a 503 error. The reason is that the float32 type of numpy will throw an exception during serialization, and the confidence type in the result predicted by pse is numpy.float32

## Modification
Convert the confidence type in the PSE post-processing file from numpy.float32 to python built-in float
![image](https://user-images.githubusercontent.com/65162523/196099397-b23acd4a-cc44-41e8-aec8-03c6ded8ec3a.png)

