### PR TITLE
[Fix] Fix offline_eval error caused by new data flow

### DIFF
--- a/tools/analysis_tools/offline_eval.py
+++ b/tools/analysis_tools/offline_eval.py
@@ -6,7 +6,6 @@ import mmengine
 from mmengine.config import Config, DictAction
 from mmengine.evaluator import Evaluator
 
-from mmocr.registry import DATASETS
 from mmocr.utils import register_all_modules
 
 
@@ -44,8 +43,7 @@ def main():
     predictions = mmengine.load(args.pkl_results)
 
     evaluator = Evaluator(cfg.test_evaluator)
-    dataset = DATASETS.build(cfg.test_dataloader.dataset)
-    eval_results = evaluator.offline_evaluate(dataset, predictions)
+    eval_results = evaluator.offline_evaluate(predictions)
     print(json.dumps(eval_results))
 
 


### PR DESCRIPTION
Fixed https://github.com/open-mmlab/mmocr/issues/1496

## Motivation

The new OpenMMLab convention now requires every test-time DataSample output to contain both ground truth and prediction information. MMEngine has changed its `offline_evaluate` interface accordingly but MMOCR's offline_eval.py hasn't.
