### PR TITLE
[Feature] Support browse_dataset.py to visualize original dataset

### DIFF
--- a/docs/en/user_guides/dataset_prepare.md
+++ b/docs/en/user_guides/dataset_prepare.md
@@ -80,6 +80,12 @@ data/icdar2015
 └── textdet_train.json
 ```
 
+Once your dataset has been prepared, you can use the [browse_dataset.py](./useful_tools.md#dataset-visualization-tool) to visualize the dataset and check if the annotations are correct.
+
+```bash
+python tools/analysis_tools/browse_dataset.py configs/textdet/_base_/datasets/icdar2015.py
+```
+
 ## Dataset Configuration
 
 ### Single Dataset Training

--- a/docs/en/user_guides/useful_tools.md
+++ b/docs/en/user_guides/useful_tools.md
@@ -4,10 +4,12 @@
 
 ### Dataset Visualization Tool
 
-MMOCR provides a dataset visualization tool `tools/analysis_tools/browse_datasets.py` to help users troubleshoot possible dataset-related problems. You just need to specify the path to the training config and the tool will automatically plots the images transformed by corresponding data pipelines with the GT labels. The following example demonstrates how to use the tool to visualize the training data used by the "DBNet_R50_icdar2015" model.
+MMOCR provides a dataset visualization tool `tools/analysis_tools/browse_datasets.py` to help users troubleshoot possible dataset-related problems. You just need to specify the path to the training config (usually stored in `configs/textdet/dbnet/xxx.py`) or the dataset config (usually stored in `configs/textdet/_base_/datasets/xxx.py`), and the tool will automatically plots the transformed (or original) images and labels.
+
+The following example demonstrates how to use the tool to visualize the training data used by the "DBNet_R50_icdar2015" model.
 
 ```Bash
-# Example: Visualizing the training data used by dbnet_r50dcn_v2_fpnc_1200e_icadr2015
+# Example: Visualizing the training data used by dbnet_r50dcn_v2_fpnc_1200e_icadr2015 model
 python tools/analysis_tools/browse_dataset.py configs/textdet/dbnet/dbnet_r50dcnv2_fpnc_1200e_icdar2015.py
 ```
 
@@ -16,6 +18,12 @@ The visualization results will be like:
 <center class="half">
     <img src="https://user-images.githubusercontent.com/24622904/187611542-01e9aa94-fc12-4756-964b-a0e472522a3a.jpg" width="250"/><img src="https://user-images.githubusercontent.com/24622904/187611555-3f5ea616-863d-4538-884f-bccbebc2f7e7.jpg" width="250"/><img src="https://user-images.githubusercontent.com/24622904/187611581-88be3970-fbfe-4f62-8cdf-7a8a7786af29.jpg" width="250"/>
 </center>
+
+In addition, users can also visualize the original images and their corresponding labels of the dataset by specifying the path to the dataset config file, for example:
+
+```Bash
+python tools/analysis_tools/browse_dataset.py configs/textdet/_base_/datasets/icdar2015.py
+```
 
 Based on this tool, users can easily verify if the annotation of a custom dataset is correct. Also, you can verify if the data augmentation strategies are running as you expected by modifying `train_pipeline` in the configuration file. The optional parameters of `browse_dataset.py` are as follows.
 

--- a/docs/en/user_guides/useful_tools.md
+++ b/docs/en/user_guides/useful_tools.md
@@ -6,32 +6,89 @@
 
 MMOCR provides a dataset visualization tool `tools/analysis_tools/browse_datasets.py` to help users troubleshoot possible dataset-related problems. You just need to specify the path to the training config (usually stored in `configs/textdet/dbnet/xxx.py`) or the dataset config (usually stored in `configs/textdet/_base_/datasets/xxx.py`), and the tool will automatically plots the transformed (or original) images and labels.
 
+#### Usage
+
+```bash
+python tools/visualizations/browse_dataset.py \
+    ${CONFIG_FILE} \
+    [-o, --output-dir ${OUTPUT_DIR}] \
+    [-p, --phase ${DATASET_PHASE}] \
+    [-m, --mode ${DISPLAY_MODE}] \
+    [-t, --task ${DATASET_TASK}] \
+    [-n, --show-number ${NUMBER_IMAGES_DISPLAY}] \
+    [-i, --show-interval ${SHOW_INTERRVAL}] \
+    [--cfg-options ${CFG_OPTIONS}]
+```
+
+| ARGS                | Type                                  | Description                                                                                                                                      |
+| ------------------- | ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| config              | str                                   | (required) Path to the config.                                                                                                                   |
+| -o, --output-dir    | str                                   | If GUI is not available, specifying an output path to save the visualization results.                                                            |
+| -p, --phase         | str                                   | Phase of dataset to visualize. Use "train", "test" or "val" if you just want to visualize the default split. It's also possible to be a dataset variable name, which might be useful when a dataset split has multiple variants in the config. |
+| -m, --mode          | `original`, `transformed`, `pipeline` | Display mode: display original pictures or transformed pictures or comparison pictures. `original` only visualizes the original dataset & annotations; `transformed` shows the resulting images processed through all the transforms; `pipeline` shows all the intermediate images. Defaults to "transformed". |
+| -t, --task          | `auto`, `textdet`, `textrecog`        | Specify the task type of the dataset. If `auto`, the task type will be inferred from the config. If the script is unable to infer the task type, you need to specify it manually. Defaults to `auto`. |
+| -n, --show-number   | int                                   | The number of samples to visualized. If not specified, display all images in the dataset.                                                        |
+| -i, --show-interval | float                                 | Interval of visualization (s), defaults to 2.                                                                                                    |
+| --cfg-options       | float                                 | Override configs. [Example](./config.md#command-line-modification)                                                                               |
+
+#### Examples
+
 The following example demonstrates how to use the tool to visualize the training data used by the "DBNet_R50_icdar2015" model.
 
 ```Bash
 # Example: Visualizing the training data used by dbnet_r50dcn_v2_fpnc_1200e_icadr2015 model
-python tools/analysis_tools/browse_dataset.py configs/textdet/dbnet/dbnet_r50dcnv2_fpnc_1200e_icdar2015.py
+python tools/analysis_tools/browse_dataset.py configs/textdet/dbnet/dbnet_resnet50-dcnv2_fpnc_1200e_icdar2015.py
 ```
 
-The visualization results will be like:
+By default, the visualization mode is "transformed", and you will see the images & annotations being transformed by the pipeline:
 
 <center class="half">
     <img src="https://user-images.githubusercontent.com/24622904/187611542-01e9aa94-fc12-4756-964b-a0e472522a3a.jpg" width="250"/><img src="https://user-images.githubusercontent.com/24622904/187611555-3f5ea616-863d-4538-884f-bccbebc2f7e7.jpg" width="250"/><img src="https://user-images.githubusercontent.com/24622904/187611581-88be3970-fbfe-4f62-8cdf-7a8a7786af29.jpg" width="250"/>
 </center>
 
+If you just want to visualize the original dataset, simply set the mode to "original":
+
+```Bash
+python tools/analysis_tools/browse_dataset.py configs/textdet/dbnet/dbnet_resnet50-dcnv2_fpnc_1200e_icdar2015.py -m original
+```
+
+<div align=center><img src="https://user-images.githubusercontent.com/22607038/206646570-382d0f26-908a-4ab4-b1a7-5cc31fa70c5f.jpg" style=" width: auto; height: 40%; "></div>
+
+Or, to visualize the entire pipeline:
+
+```Bash
+python tools/analysis_tools/browse_dataset.py configs/textdet/dbnet/dbnet_resnet50-dcnv2_fpnc_1200e_icdar2015.py -m pipeline
+```
+
+<div align=center><img src="https://user-images.githubusercontent.com/22607038/206637571-287640c0-1f55-453f-a2fc-9f9734b9593f.jpg" style=" width: auto; height: 40%; "></div>
+
 In addition, users can also visualize the original images and their corresponding labels of the dataset by specifying the path to the dataset config file, for example:
 
 ```Bash
-python tools/analysis_tools/browse_dataset.py configs/textdet/_base_/datasets/icdar2015.py
+python tools/analysis_tools/browse_dataset.py configs/textrecog/_base_/datasets/icdar2015.py
 ```
 
-Based on this tool, users can easily verify if the annotation of a custom dataset is correct. Also, you can verify if the data augmentation strategies are running as you expected by modifying `train_pipeline` in the configuration file. The optional parameters of `browse_dataset.py` are as follows.
+Some datasets might have multiple variants. For example, the test split of `icdar2015` textrecog dataset has two variants, which the [base dataset config](/configs/textrecog/_base_/datasets/icdar2015.py) defines as follows:
 
-| ARGS            | Type  | Description                                                                           |
-| --------------- | ----- | ------------------------------------------------------------------------------------- |
-| config          | str   | (required) Path to the config.                                                        |
-| --output-dir    | str   | If GUI is not available, specifying an output path to save the visualization results. |
-| --show-interval | float | Interval of visualization (s), defaults to 2.                                         |
+```python
+icdar2015_textrecog_test = dict(
+    ann_file='textrecog_test.json',
+    # ...
+    )
+
+icdar2015_1811_textrecog_test = dict(
+    ann_file='textrecog_test_1811.json',
+    # ...
+)
+```
+
+In this case, you can specify the variant name to visualize the corresponding dataset:
+
+```Bash
+python tools/analysis_tools/browse_dataset.py configs/textrecog/_base_/datasets/icdar2015.py -p icdar2015_1811_textrecog_test
+```
+
+Based on this tool, users can easily verify if the annotation of a custom dataset is correct.
 
 ### Offline Evaluation Tool
 

--- a/docs/zh_cn/user_guides/dataset_prepare.md
+++ b/docs/zh_cn/user_guides/dataset_prepare.md
@@ -80,6 +80,12 @@ data/icdar2015
 └── textdet_train.json
 ```
 
+数据准备完毕以后，你也可以通过使用我们提供的数据集浏览工具 [browse_dataset.py](./useful_tools.md#数据集可视化工具) 来可视化数据集的标签是否被正确生成，例如：
+
+```bash
+python tools/analysis_tools/browse_dataset.py configs/textdet/_base_/datasets/icdar2015.py
+```
+
 ## 数据集配置文件
 
 ### 单数据集训练

--- a/docs/zh_cn/user_guides/useful_tools.md
+++ b/docs/zh_cn/user_guides/useful_tools.md
@@ -4,10 +4,12 @@
 
 ### 数据集可视化工具
 
-MMOCR 提供了数据集可视化工具 `tools/analysis_tools/browse_datasets.py` 以辅助用户排查可能遇到的数据集相关的问题。用户只需要指定所使用的训练配置文件路径，该工具即可自动将经过数据流水线（data pipeline）处理过的图像及其对应的真实标签绘制出来。例如，以下命令演示了如何使用该工具对 "DBNet_R50_icdar2015" 模型使用的训练数据进行可视化操作：
+MMOCR 提供了数据集可视化工具 `tools/analysis_tools/browse_datasets.py` 以辅助用户排查可能遇到的数据集相关的问题。用户只需要指定所使用的训练配置文件（通常存放在如 `configs/textdet/dbnet/xxx.py` 文件中）或数据集配置（通常存放在 `configs/textdet/_base_/datasets/xxx.py` 文件中）路径。该工具将依据输入的配置文件类型自动将经过数据流水线（data pipeline）处理过的图像及其对应的标签，或原始图片及其对应的标签绘制出来。
+
+例如，以下命令演示了如何使用该工具对 "DBNet_R50_icdar2015" 模型使用的经过数据变换的训练数据进行可视化操作：
 
 ```Bash
-# 示例：可视化 dbnet_r50dcn_v2_fpnc_1200e_icadr2015 使用的训练数据
+# 示例：可视化 dbnet_r50dcn_v2_fpnc_1200e_icadr2015 模型使用的训练数据
 python tools/analysis_tools/browse_dataset.py configs/textdet/dbnet/dbnet_r50dcnv2_fpnc_1200e_icdar2015.py
 ```
 
@@ -16,6 +18,12 @@ python tools/analysis_tools/browse_dataset.py configs/textdet/dbnet/dbnet_r50dcn
 <center class="half">
     <img src="https://user-images.githubusercontent.com/24622904/187611542-01e9aa94-fc12-4756-964b-a0e472522a3a.jpg" width="250"/><img src="https://user-images.githubusercontent.com/24622904/187611555-3f5ea616-863d-4538-884f-bccbebc2f7e7.jpg" width="250"/><img src="https://user-images.githubusercontent.com/24622904/187611581-88be3970-fbfe-4f62-8cdf-7a8a7786af29.jpg" width="250"/>
 </center>
+
+另外，用户也可以通过输入数据集配置文件路径来可视化数据集的原始图像及其对应的标签：
+
+```Bash
+python tools/analysis_tools/browse_dataset.py configs/textdet/_base_/datasets/icdar2015.py
+```
 
 基于此工具，用户可以方便地验证自定义数据集的标注格式是否正确；也可以通过修改配置文件中的 `train_pipeline` 来验证不同的数据增强策略组合是否符合自己的预期。`browse_dataset.py` 的可选参数如下：
 

--- a/docs/zh_cn/user_guides/useful_tools.md
+++ b/docs/zh_cn/user_guides/useful_tools.md
@@ -4,6 +4,10 @@
 
 ### 数据集可视化工具
 
+```{note}
+本工具的中文文档已经过时，请以英文文档为准。如果您有兴趣参与本节中文文档的翻译，欢迎通过 [Issue: Documentation](https://github.com/open-mmlab/mmocr/issues/new?assignees=&labels=docs&template=4-documentation.yml&title=%5BDocs%5D+) 及时告知我们：）
+```
+
 MMOCR 提供了数据集可视化工具 `tools/analysis_tools/browse_datasets.py` 以辅助用户排查可能遇到的数据集相关的问题。用户只需要指定所使用的训练配置文件（通常存放在如 `configs/textdet/dbnet/xxx.py` 文件中）或数据集配置（通常存放在 `configs/textdet/_base_/datasets/xxx.py` 文件中）路径。该工具将依据输入的配置文件类型自动将经过数据流水线（data pipeline）处理过的图像及其对应的标签，或原始图片及其对应的标签绘制出来。
 
 例如，以下命令演示了如何使用该工具对 "DBNet_R50_icdar2015" 模型使用的经过数据变换的训练数据进行可视化操作：

--- a/mmocr/visualization/kie_visualizer.py
+++ b/mmocr/visualization/kie_visualizer.py
@@ -258,6 +258,9 @@ class KIELocalVisualizer(BaseLocalVisualizer):
         if out_file is not None:
             mmcv.imwrite(cat_images[..., ::-1], out_file)
 
+        self.set_image(cat_images)
+        return self.get_image()
+
     def draw_arrows(self,
                     x_data: Union[np.ndarray, torch.Tensor],
                     y_data: Union[np.ndarray, torch.Tensor],

--- a/mmocr/visualization/textdet_visualizer.py
+++ b/mmocr/visualization/textdet_visualizer.py
@@ -167,3 +167,6 @@ class TextDetLocalVisualizer(BaseLocalVisualizer):
 
         if out_file is not None:
             mmcv.imwrite(cat_images[..., ::-1], out_file)
+
+        self.set_image(cat_images)
+        return self.get_image()

--- a/mmocr/visualization/textrecog_visualizer.py
+++ b/mmocr/visualization/textrecog_visualizer.py
@@ -118,11 +118,13 @@ class TextRecogLocalVisualizer(BaseLocalVisualizer):
             image = cv2.cvtColor(image, cv2.COLOR_GRAY2RGB)
 
         cat_images = [image]
-        if draw_gt and data_sample is not None and 'gt_text' in data_sample:
+        if (draw_gt and data_sample is not None and 'gt_text' in data_sample
+                and 'item' in data_sample.gt_text):
             gt_text = data_sample.gt_text.item
             cat_images.append(self._draw_instances(image, gt_text))
         if (draw_pred and data_sample is not None
-                and 'pred_text' in data_sample):
+                and 'pred_text' in data_sample
+                and 'item' in data_sample.pred_text):
             pred_text = data_sample.pred_text.item
             cat_images.append(self._draw_instances(image, pred_text))
         cat_images = self._cat_image(cat_images, axis=0)
@@ -134,3 +136,6 @@ class TextRecogLocalVisualizer(BaseLocalVisualizer):
 
         if out_file is not None:
             mmcv.imwrite(cat_images[..., ::-1], out_file)
+
+        self.set_image(cat_images)
+        return self.get_image()

--- a/mmocr/visualization/textspotting_visualizer.py
+++ b/mmocr/visualization/textspotting_visualizer.py
@@ -133,3 +133,6 @@ class TextSpottingLocalVisualizer(BaseLocalVisualizer):
 
         if out_file is not None:
             mmcv.imwrite(cat_images[..., ::-1], out_file)
+
+        self.set_image(cat_images)
+        return self.get_image()


### PR DESCRIPTION
Now browse_dataset.py supports two modes, `model config mode` and `dataset config mode`. Users can input dataset config now, and the script will automatically select the corresponding mode.