### PR TITLE
[Fix] Fix two bugs in dataset preparer

### DIFF
--- a/mmocr/datasets/preparers/data_converter.py
+++ b/mmocr/datasets/preparers/data_converter.py
@@ -143,14 +143,14 @@ class BaseDataConverter:
         """
 
     @abstractmethod
-    def add_meta(self, sample: Dict) -> Dict:
+    def add_meta(self, sample: List) -> Dict:
         """Add meta information to the sample.
 
         Args:
-            sample (Dict): A sample of the dataset.
+            sample (List): A list of samples of the dataset.
 
         Returns:
-            Dict: A sample with meta information.
+            Dict: A dict contains the meta information and samples.
         """
 
     def mono_gather(self, ann_path: str, mapping: str, split: str,
@@ -297,7 +297,7 @@ class TextDetDataConverter(BaseDataConverter):
 
         return packed_instances
 
-    def add_meta(self, sample: Dict) -> Dict:
+    def add_meta(self, sample: List) -> Dict:
         meta = {
             'metainfo': {
                 'dataset_type': 'TextDetDataset',
@@ -396,7 +396,7 @@ class TextSpottingDataConverter(BaseDataConverter):
 
         return packed_instances
 
-    def add_meta(self, sample: Dict) -> Dict:
+    def add_meta(self, sample: List) -> Dict:
         meta = {
             'metainfo': {
                 'dataset_type': 'TextSpottingDataset',
@@ -465,7 +465,7 @@ class TextRecogDataConverter(BaseDataConverter):
 
         return packed_instance
 
-    def add_meta(self, sample: Dict) -> Dict:
+    def add_meta(self, sample: List) -> Dict:
         meta = {
             'metainfo': {
                 'dataset_type': 'TextRecogDataset',
@@ -522,7 +522,6 @@ class TextRecogCropConverter(TextRecogDataConverter):
             dataset_name=dataset_name,
             nproc=nproc,
             delete=delete)
-        self.ignore = self.parser.ignore
         self.lepr = long_edge_pad_ratio
         self.sepr = short_edge_pad_ratio
         # Crop converter crops the images of textdet to patches
@@ -555,7 +554,7 @@ class TextRecogCropConverter(TextRecogDataConverter):
         img = mmcv.imread(img_path)
         for i, instance in enumerate(instances):
             box, text = get_box(instance), instance['text']
-            if text == self.ignore:
+            if instance['ignore']:
                 continue
             patch = crop_img(img, box, self.lepr, self.sepr)
             if patch.shape[0] == 0 or patch.shape[1] == 0:
@@ -571,6 +570,25 @@ class TextRecogCropConverter(TextRecogDataConverter):
             data_list.append(rec_instance)
 
         return data_list
+
+    def add_meta(self, sample: List) -> Dict:
+        # Since the TextRecogCropConverter packs all of the patches in a single
+        # image into a list, we need to flatten the list.
+        sample = [item for sublist in sample for item in sublist]
+
+        meta = {
+            'metainfo': {
+                'dataset_type': 'TextRecogDataset',
+                'task_name': 'textrecog',
+                'category': [{
+                    'id': 0,
+                    'name': 'text'
+                }]
+            },
+            'data_list': sample
+        }
+
+        return meta
 
 
 @DATA_CONVERTERS.register_module()

--- a/mmocr/datasets/preparers/data_converter.py
+++ b/mmocr/datasets/preparers/data_converter.py
@@ -575,20 +575,7 @@ class TextRecogCropConverter(TextRecogDataConverter):
         # Since the TextRecogCropConverter packs all of the patches in a single
         # image into a list, we need to flatten the list.
         sample = [item for sublist in sample for item in sublist]
-
-        meta = {
-            'metainfo': {
-                'dataset_type': 'TextRecogDataset',
-                'task_name': 'textrecog',
-                'category': [{
-                    'id': 0,
-                    'name': 'text'
-                }]
-            },
-            'data_list': sample
-        }
-
-        return meta
+        return super().add_meta(sample)
 
 
 @DATA_CONVERTERS.register_module()

--- a/mmocr/datasets/preparers/dumpers/dumpers.py
+++ b/mmocr/datasets/preparers/dumpers/dumpers.py
@@ -40,7 +40,7 @@ class JsonDumper:
         dst_file = osp.join(data_root, f'{self.task}_{split}.json')
         mmengine.dump(data, dst_file)
 
-        cfg = f'\n{self.dataset_name}_{self.task}_{split} = dict (\n'
+        cfg = f'\n{self.dataset_name}_{self.task}_{split} = dict(\n'
         cfg += '    type=\'OCRDataset\',\n'
         cfg += '    data_root=' + f'{self.dataset_name}_{self.task}_data_root,\n'  # noqa: E501
         cfg += f'    ann_file=\'{osp.basename(dst_file)}\',\n'


### PR DESCRIPTION
1. a redundant blank in automatically generated dataset config
2. when using `TextRecogCropConverter`, the packed sample list contains multiple instances, which should be flattened:

```{json}
//  before fix bug2
data_list = [
[dict(), dict(), dict()], [dict()], [dict()]
]

// after fix bug2
data_list = [
dict(),
dict(),
dict(),
dict(),
dict()
]
```