### PR TITLE
[Fix] Fix Dataset Preparer Extract

### DIFF
--- a/mmocr/datasets/preparers/data_obtainer.py
+++ b/mmocr/datasets/preparers/data_obtainer.py
@@ -100,8 +100,8 @@ class NaiveDataObtainer:
                 to False.
         """
         if not is_archive(src_path) and not osp.exists(dst_path):
-            # Move the file to the destination folder if it is not a zip
-            shutil.move(src_path, dst_path)
+            # Copy the file to the destination folder if it is not a zip
+            shutil.copy(src_path, dst_path)
             return
 
         zip_name = osp.basename(src_path).split('.')[0]

--- a/mmocr/datasets/preparers/data_obtainer.py
+++ b/mmocr/datasets/preparers/data_obtainer.py
@@ -100,8 +100,8 @@ class NaiveDataObtainer:
                 to False.
         """
         if not is_archive(src_path) and not osp.exists(dst_path):
-            # Move the file to the destination folder if it is not a zip
-            shutil.copytree(src_path, dst_path)
+            # Copy the file to the destination folder if it is not a zip
+            shutil.copy(src_path, dst_path)
             return
 
         zip_name = osp.basename(src_path).split('.')[0]

--- a/mmocr/datasets/preparers/data_obtainer.py
+++ b/mmocr/datasets/preparers/data_obtainer.py
@@ -100,8 +100,8 @@ class NaiveDataObtainer:
                 to False.
         """
         if not is_archive(src_path) and not osp.exists(dst_path):
-            # Copy the file to the destination folder if it is not a zip
-            shutil.copy(src_path, dst_path)
+            # Move the file to the destination folder if it is not a zip
+            shutil.move(src_path, dst_path)
             return
 
         zip_name = osp.basename(src_path).split('.')[0]

--- a/mmocr/datasets/preparers/data_obtainer.py
+++ b/mmocr/datasets/preparers/data_obtainer.py
@@ -99,10 +99,9 @@ class NaiveDataObtainer:
             delete (bool, optional): Whether to delete the zip file. Defaults
                 to False.
         """
-
-        if not is_archive(src_path):
+        if not is_archive(src_path) and not osp.exists(dst_path):
             # Move the file to the destination folder if it is not a zip
-            shutil.move(src_path, dst_path)
+            shutil.copytree(src_path, dst_path)
             return
 
         zip_name = osp.basename(src_path).split('.')[0]


### PR DESCRIPTION
When re-running the data preparer, it might repeatedly download the annotation files.