### PR TITLE
[Bugs] ctc loss bug if target is empty

### DIFF
--- a/configs/textrecog/crnn/crnn_mini-vgg_5e_toy.py
+++ b/configs/textrecog/crnn/crnn_mini-vgg_5e_toy.py
@@ -33,7 +33,9 @@ val_dataloader = dict(
         pipeline=_base_.test_pipeline))
 test_dataloader = val_dataloader
 
-model = dict(decoder=dict(dictionary=dict(with_unknown=True)))
+_base_.model.decoder.dictionary.update(
+    dict(with_unknown=True, unknown_token=None))
+_base_.train_cfg.update(dict(max_epochs=200, val_interval=10))
 
 val_evaluator = dict(dataset_prefixes=['Toy'])
 test_evaluator = val_evaluator

--- a/mmocr/models/textrecog/module_losses/ctc_module_loss.py
+++ b/mmocr/models/textrecog/module_losses/ctc_module_loss.py
@@ -77,7 +77,7 @@ class CTCModuleLoss(BaseTextRecogModuleLoss):
             for data_sample in data_samples
         ]
         target_lengths = torch.IntTensor([len(t) for t in targets])
-        target_lengths = torch.clamp(target_lengths, min=1, max=seq_len).long()
+        target_lengths = torch.clamp(target_lengths, max=seq_len).long()
         input_lengths = torch.full(
             size=(bsz, ), fill_value=seq_len, dtype=torch.long)
         if self.flatten:


### PR DESCRIPTION
## Motivation

When the target is empty, the `target_length` is not equal to the actual `target_length` for
`target_lengths = torch.clamp(target_lengths, max=seq_len).long()` 


The precision of toy data in CRNN can be 100%