### PR TITLE
[Enhancement] Enhance FixInvalidPolygon, add RemoveIgnored transform

### DIFF
--- a/mmocr/datasets/transforms/__init__.py
+++ b/mmocr/datasets/transforms/__init__.py
@@ -4,11 +4,11 @@ from .formatting import PackKIEInputs, PackTextDetInputs, PackTextRecogInputs
 from .loading import (LoadImageFromFile, LoadImageFromLMDB,
                       LoadImageFromNDArray, LoadKIEAnnotations,
                       LoadOCRAnnotations)
-from .ocr_transforms import RandomCrop, RandomRotate, Resize
-from .textdet_transforms import (BoundedScaleAspectJitter, FixInvalidPolygon,
-                                 RandomFlip, ShortScaleAspectJitter,
-                                 SourceImagePad, TextDetRandomCrop,
-                                 TextDetRandomCropFlip)
+from .ocr_transforms import (FixInvalidPolygon, RandomCrop, RandomRotate,
+                             RemoveIgnored, Resize)
+from .textdet_transforms import (BoundedScaleAspectJitter, RandomFlip,
+                                 ShortScaleAspectJitter, SourceImagePad,
+                                 TextDetRandomCrop, TextDetRandomCropFlip)
 from .textrecog_transforms import PadToWidth, PyramidRescale, RescaleToHeight
 from .wrappers import ImgAugWrapper, TorchVisionWrapper
 
@@ -20,5 +20,5 @@ __all__ = [
     'ShortScaleAspectJitter', 'RandomFlip', 'BoundedScaleAspectJitter',
     'PackKIEInputs', 'LoadKIEAnnotations', 'FixInvalidPolygon', 'MMDet2MMOCR',
     'MMOCR2MMDet', 'LoadImageFromLMDB', 'LoadImageFromFile',
-    'LoadImageFromNDArray'
+    'LoadImageFromNDArray', 'RemoveIgnored'
 ]

--- a/mmocr/datasets/transforms/ocr_transforms.py
+++ b/mmocr/datasets/transforms/ocr_transforms.py
@@ -11,7 +11,9 @@ from mmcv.transforms.utils import avoid_cache_randomness, cache_randomness
 
 from mmocr.registry import TRANSFORMS
 from mmocr.utils import (bbox2poly, crop_polygon, is_poly_inside_rect,
-                         poly2bbox, remove_pipeline_elements, rescale_polygon)
+                         poly2bbox, poly2shapely, poly_make_valid,
+                         remove_pipeline_elements, rescale_polygon,
+                         shapely2poly)
 from .wrappers import ImgAugWrapper
 
 
@@ -641,3 +643,108 @@ class RemoveIgnored(BaseTransform):
         if len(remove_inds) == len(results['gt_ignored']):
             return None
         return remove_pipeline_elements(results, remove_inds)
+
+
+@TRANSFORMS.register_module()
+class FixInvalidPolygon(BaseTransform):
+    """Fix invalid polygons in the dataset.
+
+    Required Keys:
+
+    - gt_polygons
+    - gt_ignored (optional)
+    - gt_bboxes (optional)
+    - gt_bboxes_labels (optional)
+    - gt_texts (optional)
+
+    Modified Keys:
+
+    - gt_polygons
+    - gt_ignored (optional)
+    - gt_bboxes (optional)
+    - gt_bboxes_labels (optional)
+    - gt_texts (optional)
+
+    Args:
+        mode (str): The mode of fixing invalid polygons. Options are 'fix' and
+            'ignore'.
+            For the 'fix' mode, the transform will try to fix
+            the invalid polygons to a valid one by eliminating the
+            self-intersection or converting the bboxes to polygons. If
+            it can't be fixed by any means (e.g. the polygon contains less
+            than 3 points or it's actually a line/point), the annotation will
+            be removed.
+            For the 'ignore' mode, the invalid polygons
+            will be set to "ignored" during training.
+            Defaults to 'fix'.
+        min_poly_points (int): Minimum number of the coordinate points in a
+            polygon. Defaults to 4.
+    """
+
+    def __init__(self, mode: str = 'fix', min_poly_points: int = 4) -> None:
+        super().__init__()
+        self.mode = mode
+        assert min_poly_points >= 3, 'min_poly_points must be greater than 3.'
+        self.min_poly_points = min_poly_points
+        assert self.mode in [
+            'fix', 'ignore'
+        ], f"Supported modes are 'fix' and 'ignore', but got {self.mode}"
+
+    def transform(self, results: Dict) -> Dict:
+        """Fix invalid polygons.
+
+        Args:
+            results (dict): Result dict containing the data to transform.
+
+        Returns:
+            Optional[dict]: The transformed data. If all the polygons are
+            unfixable, return None.
+        """
+        if results.get('gt_polygons', None) is not None:
+            remove_inds = []
+            for idx, polygon in enumerate(results['gt_polygons']):
+                if self.mode == 'ignore':
+                    if results['gt_ignored'][idx]:
+                        continue
+                    if not (len(polygon) >= self.min_poly_points * 2
+                            and len(polygon) % 2
+                            == 0) or not poly2shapely(polygon).is_valid:
+                        results['gt_ignored'][idx] = True
+                else:
+                    # If "polygon" contains less than 3 points
+                    if len(polygon) < 6:
+                        remove_inds.append(idx)
+                        continue
+                    try:
+                        shapely_polygon = poly2shapely(polygon)
+                        if shapely_polygon.is_valid and len(
+                                polygon) >= self.min_poly_points * 2:
+                            continue
+                        results['gt_polygons'][idx] = shapely2poly(
+                            poly_make_valid(shapely_polygon))
+                        # If an empty polygon is generated, it's still a bad
+                        # fix
+                        if len(results['gt_polygons'][idx]) == 0:
+                            raise ValueError
+                    # It's hard to fix, e.g. the "polygon" is a line or
+                    # a point
+                    except Exception:
+                        if 'gt_bboxes' in results:
+                            bbox = results['gt_bboxes'][idx]
+                            bbox_polygon = bbox2poly(bbox)
+                            results['gt_polygons'][idx] = bbox_polygon
+                            shapely_polygon = poly2shapely(bbox_polygon)
+                            if (not shapely_polygon.is_valid
+                                    or shapely_polygon.is_empty):
+                                remove_inds.append(idx)
+                        else:
+                            remove_inds.append(idx)
+        if len(remove_inds) == len(results['gt_polygons']):
+            return None
+        return remove_pipeline_elements(results, remove_inds)
+
+    def __repr__(self) -> str:
+        repr_str = self.__class__.__name__
+        repr_str += f'(mode = "{self.mode}", '
+        repr_str += f'min_poly_points = {self.min_poly_points})'
+        return repr_str

--- a/mmocr/datasets/transforms/ocr_transforms.py
+++ b/mmocr/datasets/transforms/ocr_transforms.py
@@ -679,13 +679,19 @@ class FixInvalidPolygon(BaseTransform):
             Defaults to 'fix'.
         min_poly_points (int): Minimum number of the coordinate points in a
             polygon. Defaults to 4.
+        fix_from_bbox (bool): Whether to convert the bboxes to polygons when
+            the polygon is invalid and not directly fixable. Defaults to True.
     """
 
-    def __init__(self, mode: str = 'fix', min_poly_points: int = 4) -> None:
+    def __init__(self,
+                 mode: str = 'fix',
+                 min_poly_points: int = 4,
+                 fix_from_bbox: bool = True) -> None:
         super().__init__()
         self.mode = mode
         assert min_poly_points >= 3, 'min_poly_points must be greater than 3.'
         self.min_poly_points = min_poly_points
+        self.fix_from_bbox = fix_from_bbox
         assert self.mode in [
             'fix', 'ignore'
         ], f"Supported modes are 'fix' and 'ignore', but got {self.mode}"
@@ -729,7 +735,7 @@ class FixInvalidPolygon(BaseTransform):
                     # It's hard to fix, e.g. the "polygon" is a line or
                     # a point
                     except Exception:
-                        if 'gt_bboxes' in results:
+                        if self.fix_from_bbox and 'gt_bboxes' in results:
                             bbox = results['gt_bboxes'][idx]
                             bbox_polygon = bbox2poly(bbox)
                             results['gt_polygons'][idx] = bbox_polygon
@@ -746,5 +752,6 @@ class FixInvalidPolygon(BaseTransform):
     def __repr__(self) -> str:
         repr_str = self.__class__.__name__
         repr_str += f'(mode = "{self.mode}", '
-        repr_str += f'min_poly_points = {self.min_poly_points})'
+        repr_str += f'min_poly_points = {self.min_poly_points}, '
+        repr_str += f'fix_from_bbox = {self.fix_from_bbox})'
         return repr_str

--- a/mmocr/datasets/transforms/ocr_transforms.py
+++ b/mmocr/datasets/transforms/ocr_transforms.py
@@ -745,9 +745,10 @@ class FixInvalidPolygon(BaseTransform):
                                 remove_inds.append(idx)
                         else:
                             remove_inds.append(idx)
-        if len(remove_inds) == len(results['gt_polygons']):
-            return None
-        return remove_pipeline_elements(results, remove_inds)
+            if len(remove_inds) == len(results['gt_polygons']):
+                return None
+            results = remove_pipeline_elements(results, remove_inds)
+        return results
 
     def __repr__(self) -> str:
         repr_str = self.__class__.__name__

--- a/mmocr/datasets/transforms/ocr_transforms.py
+++ b/mmocr/datasets/transforms/ocr_transforms.py
@@ -613,3 +613,24 @@ class Resize(MMCV_Resize):
         repr_str += f'backend={self.backend}), '
         repr_str += f'interpolation={self.interpolation})'
         return repr_str
+
+
+@TRANSFORMS.register_module()
+class RemoveIgnored(BaseTransform):
+
+    def transform(self, results: Dict):
+        gt_ignored = results['gt_ignored']
+        need_index = np.where(~gt_ignored)[0]
+        if len(need_index) == 0:
+            return None
+        results['gt_ignored'] = gt_ignored[need_index]
+        if 'gt_bboxes' in results:
+            results['gt_bboxes'] = results['gt_bboxes'][need_index]
+        gt_polygons = results['gt_polygons']
+        new_gt_polygon = [gt_polygons[i] for i in need_index]
+        results['gt_polygons'] = new_gt_polygon
+        results['gt_bboxes_labels'] = results['gt_bboxes_labels'][need_index]
+        if 'gt_texts' in results:
+            gt_texts = results['gt_texts']
+            results['gt_texts'] = [gt_texts[i] for i in need_index]
+        return results

--- a/mmocr/datasets/transforms/textdet_transforms.py
+++ b/mmocr/datasets/transforms/textdet_transforms.py
@@ -13,7 +13,8 @@ from shapely.geometry import Polygon as plg
 
 from mmocr.registry import TRANSFORMS
 from mmocr.utils import (bbox2poly, crop_polygon, poly2bbox, poly2shapely,
-                         poly_intersection, poly_make_valid, shapely2poly)
+                         poly_intersection, poly_make_valid,
+                         remove_pipeline_elements, shapely2poly)
 
 
 @TRANSFORMS.register_module()
@@ -122,32 +123,40 @@ class FixInvalidPolygon(BaseTransform):
     Required Keys:
 
     - gt_polygons
-    - gt_ignored
+    - gt_ignored (optional)
+    - gt_bboxes (optional)
+    - gt_bboxes_labels (optional)
+    - gt_texts (optional)
 
     Modified Keys:
 
     - gt_polygons
-    - gt_ignored
+    - gt_ignored (optional)
+    - gt_bboxes (optional)
+    - gt_bboxes_labels (optional)
+    - gt_texts (optional)
 
     Args:
         mode (str): The mode of fixing invalid polygons. Options are 'fix' and
-            'ignore'. For the 'fix' mode, the transform will try to fix
+            'ignore'.
+            For the 'fix' mode, the transform will try to fix
             the invalid polygons to a valid one by eliminating the
-            self-intersection. For the 'ignore' mode, the invalid polygons
-            will be ignored during training. Defaults to 'fix'.
+            self-intersection or converting the bboxes to polygons. If
+            it can't be fixed by any means (e.g. the polygon contains less
+            than 3 points or it's actually a line/point), the annotation will
+            be removed.
+            For the 'ignore' mode, the invalid polygons
+            will be set to "ignored" during training.
+            Defaults to 'fix'.
         min_poly_points (int): Minimum number of the coordinate points in a
-            polygon. Defaults to 3.
+            polygon. Defaults to 4.
     """
 
-    def __init__(self,
-                 mode: str = 'fix',
-                 min_poly_points: int = 4,
-                 prompt='') -> None:
+    def __init__(self, mode: str = 'fix', min_poly_points: int = 4) -> None:
         super().__init__()
         self.mode = mode
         assert min_poly_points >= 3, 'min_poly_points must be greater than 3.'
         self.min_poly_points = min_poly_points
-        self.prompt = prompt
         assert self.mode in [
             'fix', 'ignore'
         ], f"Supported modes are 'fix' and 'ignore', but got {self.mode}"
@@ -162,56 +171,42 @@ class FixInvalidPolygon(BaseTransform):
             dict: The transformed data.
         """
         if results.get('gt_polygons', None) is not None:
+            remove_inds = []
             for idx, polygon in enumerate(results['gt_polygons']):
-                if results['gt_ignored'][idx]:
-                    continue
                 if self.mode == 'ignore':
+                    if results['gt_ignored'][idx]:
+                        continue
                     if not (len(polygon) >= self.min_poly_points * 2
                             and len(polygon) % 2
-                            == 0) or poly2shapely(polygon).is_valid:
+                            == 0) or not poly2shapely(polygon).is_valid:
                         results['gt_ignored'][idx] = True
                 else:
-                    # If the number of points satisfies the minimum number of
-                    # points
-                    if (len(polygon) >= self.min_poly_points * 2
-                            and len(polygon) % 2 == 0):
-                        import copy
-                        p_polygon = copy.deepcopy(polygon)
-                        polygon = poly2shapely(polygon)
-                        if not polygon.is_valid:
-                            print(f'from {self.prompt}, line 180 , '
-                                  f'polygon {p_polygon}')
-                            polygon = poly_make_valid(polygon)
-                            polygon = shapely2poly(polygon)
-                            results['gt_polygons'][idx] = polygon
-                    else:
-                        # If "polygon" contains less than 3 points
-                        if len(polygon) < 6:
-                            print(f'from {self.prompt}, line 187, '
-                                  f'polygon {polygon}')
-                            results['gt_ignored'][idx] = True
+                    # If "polygon" contains less than 3 points
+                    if len(polygon) < 6:
+                        remove_inds.append(idx)
+                    try:
+                        shapely_polygon = poly2shapely(polygon)
+                        if shapely_polygon.is_valid:
                             continue
-                        try:
-                            results['gt_polygons'][idx] = shapely2poly(
-                                poly_make_valid(poly2shapely(polygon)))
-                            print(f'from {self.prompt}, line 193, '
-                                  f'polygon {results["gt_polygons"][idx]}')
-                        except Exception:
-                            if 'gt_bboxes' in results:
-                                results['gt_polygons'][idx] = bbox2poly(
-                                    results['gt_bboxes'][idx])
-                                print(f'from {self.prompt}, line 202, '
-                                      f'polygon {results["gt_polygons"][idx]}')
-                            else:
-                                results['gt_ignored'][idx] = True
-                                print(f' from {self.prompt}, line 205, '
-                                      f'polygon {results["gt_polygons"][idx]}')
-
-        return results
+                        results['gt_polygons'][idx] = shapely2poly(
+                            poly_make_valid(shapely_polygon))
+                    # It's hard to fix, e.g. the "polygon" is a line or
+                    # a point
+                    except Exception:
+                        if 'gt_bboxes' in results:
+                            bbox = results['gt_bboxes'][idx]
+                            bbox_polygon = bbox2poly(bbox)
+                            results['gt_polygons'][idx] = bbox_polygon
+                            if not poly2shapely(bbox_polygon).is_valid:
+                                remove_inds.append(idx)
+        if len(remove_inds) == len(results['gt_polygons']):
+            return None
+        return remove_pipeline_elements(results, remove_inds)
 
     def __repr__(self) -> str:
         repr_str = self.__class__.__name__
-        repr_str += f'(mode = "{self.mode}")'
+        repr_str += f'(mode = "{self.mode}", '
+        repr_str += f'min_poly_points = "{self.min_poly_points}")'
         return repr_str
 
 

--- a/mmocr/datasets/transforms/wrappers.py
+++ b/mmocr/datasets/transforms/wrappers.py
@@ -64,6 +64,7 @@ class ImgAugWrapper(BaseTransform):
                     'args should be a list of list or dict'
         self.args = args
         self.augmenter = self._build_augmentation(args)
+        self.fix_poly_trans = fix_poly_trans
         if fix_poly_trans is not None:
             self.fix = TRANSFORMS.build(fix_poly_trans)
 
@@ -230,7 +231,7 @@ class ImgAugWrapper(BaseTransform):
     def __repr__(self):
         repr_str = self.__class__.__name__
         repr_str += f'(args = {self.args}, '
-        repr_str += f'fix_poly = {self.fix_poly})'
+        repr_str += f'fix_poly_trans = {self.fix_poly_trans})'
         return repr_str
 
 

--- a/mmocr/utils/__init__.py
+++ b/mmocr/utils/__init__.py
@@ -20,6 +20,7 @@ from .polygon_utils import (boundary_iou, crop_polygon, is_poly_inside_rect,
                             sort_vertex, sort_vertex8)
 from .setup_env import register_all_modules
 from .string_utils import StringStripper
+from .transform_utils import remove_pipeline_elements
 from .typing_utils import (ColorType, ConfigType, DetSampleList,
                            InitConfigType, InstanceList, KIESampleList,
                            LabelList, MultiConfig, OptConfigType,
@@ -45,5 +46,5 @@ __all__ = [
     'OptRecSampleList', 'RecSampleList', 'MultiConfig', 'OptTensor',
     'ColorType', 'OptKIESampleList', 'KIESampleList', 'is_archive',
     'check_integrity', 'list_files', 'get_md5', 'InstanceList', 'LabelList',
-    'OptInstanceList', 'OptLabelList', 'RangeType'
+    'OptInstanceList', 'OptLabelList', 'RangeType', 'remove_pipeline_elements'
 ]

--- a/mmocr/utils/polygon_utils.py
+++ b/mmocr/utils/polygon_utils.py
@@ -159,10 +159,6 @@ def crop_polygon(polygon: ArrayLike,
     else:
         poly_cropped = poly_make_valid(poly_cropped)
         poly_cropped = np.array(poly_cropped.boundary.xy, dtype=np.float32)
-        # If the polygon contains more than 4 points, the last point
-        # is the same as the first point and can be removed.
-        if len(poly_cropped) > 8:
-            poly_cropped = poly_cropped[:, :-1]
         poly_cropped = poly_cropped.T
         # reverse poly_cropped to have clockwise order
         poly_cropped = poly_cropped[::-1, :].reshape(-1)

--- a/mmocr/utils/polygon_utils.py
+++ b/mmocr/utils/polygon_utils.py
@@ -157,8 +157,13 @@ def crop_polygon(polygon: ArrayLike,
         # polygon, return None.
         return None
     else:
+        poly_cropped = poly_make_valid(poly_cropped)
         poly_cropped = np.array(poly_cropped.boundary.xy, dtype=np.float32)
-        poly_cropped = poly_cropped[:, :-1].T
+        # If the polygon contains more than 4 points, the last point
+        # is the same as the first point and can be removed.
+        if len(poly_cropped) > 8:
+            poly_cropped = poly_cropped[:, :-1]
+        poly_cropped = poly_cropped.T
         # reverse poly_cropped to have clockwise order
         poly_cropped = poly_cropped[::-1, :].reshape(-1)
         return poly_cropped
@@ -175,7 +180,10 @@ def poly_make_valid(poly: Polygon) -> Polygon:
         Polygon: A valid polygon.
     """
     assert isinstance(poly, Polygon)
-    return poly if poly.is_valid else poly.buffer(0)
+    fixed_poly = poly if poly.is_valid else poly.buffer(0)
+    if not isinstance(fixed_poly, Polygon):
+        fixed_poly = fixed_poly.convex_hull
+    return fixed_poly
 
 
 def poly_intersection(poly_a: Polygon,

--- a/mmocr/utils/polygon_utils.py
+++ b/mmocr/utils/polygon_utils.py
@@ -167,13 +167,14 @@ def crop_polygon(polygon: ArrayLike,
 
 def poly_make_valid(poly: Polygon) -> Polygon:
     """Convert a potentially invalid polygon to a valid one by eliminating
-    self-crossing or self-touching parts.
+    self-crossing or self-touching parts. Note that if the input is a line, the
+    returned polygon could be an empty one.
 
     Args:
         poly (Polygon): A polygon needed to be converted.
 
     Returns:
-        Polygon: A valid polygon.
+        Polygon: A valid polygon, which might be empty.
     """
     assert isinstance(poly, Polygon)
     fixed_poly = poly if poly.is_valid else poly.buffer(0)

--- a/mmocr/utils/polygon_utils.py
+++ b/mmocr/utils/polygon_utils.py
@@ -178,6 +178,9 @@ def poly_make_valid(poly: Polygon) -> Polygon:
     """
     assert isinstance(poly, Polygon)
     fixed_poly = poly if poly.is_valid else poly.buffer(0)
+    # Sometimes the fixed_poly is still a MultiPolygon,
+    # so we need to find the convex hull of the MultiPolygon, which should
+    # always be a Polygon (but could be empty).
     if not isinstance(fixed_poly, Polygon):
         fixed_poly = fixed_poly.convex_hull
     return fixed_poly

--- a/mmocr/utils/transform_utils.py
+++ b/mmocr/utils/transform_utils.py
@@ -1,0 +1,57 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+from typing import Dict, List, Union
+
+import numpy as np
+
+
+def remove_pipeline_elements(results: Dict,
+                             remove_inds: Union[List[int],
+                                                np.ndarray]) -> Dict:
+    """Remove elements in the pipeline given target indexes.
+
+    Args:
+        results (dict): Result dict from loading pipeline.
+        remove_inds (list(int) or np.ndarray): The element indexes to be
+            removed.
+
+    Required Keys:
+
+    - gt_polygons (optional)
+    - gt_bboxes (optional)
+    - gt_bboxes_labels (optional)
+    - gt_ignored (optional)
+    - gt_texts (optional)
+
+    Modified Keys:
+
+    - gt_polygons (optional)
+    - gt_bboxes (optional)
+    - gt_bboxes_labels (optional)
+    - gt_ignored (optional)
+    - gt_texts (optional)
+
+    Returns:
+        dict: The results with element removed.
+    """
+    keys = [
+        'gt_polygons', 'gt_bboxes', 'gt_bboxes_labels', 'gt_ignored',
+        'gt_texts'
+    ]
+    num_elements = -1
+    for key in keys:
+        if key in results:
+            num_elements = len(results[key])
+            break
+    if num_elements == -1:
+        return results
+    kept_inds = np.array(
+        [i for i in range(num_elements) if i not in remove_inds])
+    for key in keys:
+        if key in results:
+            if results[key] is np.ndarray:
+                results[key] = results[key][kept_inds]
+            elif results[key] is list:
+                results[key] = [results[key][i] for i in kept_inds]
+            else:
+                raise NotImplementedError
+    return results

--- a/mmocr/utils/transform_utils.py
+++ b/mmocr/utils/transform_utils.py
@@ -48,9 +48,9 @@ def remove_pipeline_elements(results: Dict,
         [i for i in range(num_elements) if i not in remove_inds])
     for key in keys:
         if key in results:
-            if results[key] is np.ndarray:
+            if isinstance(results[key], np.ndarray):
                 results[key] = results[key][kept_inds]
-            elif results[key] is list:
+            elif isinstance(results[key], list):
                 results[key] = [results[key][i] for i in kept_inds]
             else:
                 raise NotImplementedError

--- a/mmocr/utils/transform_utils.py
+++ b/mmocr/utils/transform_utils.py
@@ -53,5 +53,6 @@ def remove_pipeline_elements(results: Dict,
             elif isinstance(results[key], list):
                 results[key] = [results[key][i] for i in kept_inds]
             else:
-                raise NotImplementedError
+                raise TypeError(
+                    f'Unsupported type {type(results[key])} for key {key}')
     return results

--- a/tests/test_datasets/test_transforms/test_adapters.py
+++ b/tests/test_datasets/test_transforms/test_adapters.py
@@ -118,16 +118,15 @@ class TestMMDet2MMOCR(unittest.TestCase):
         t4 = Resize(scale=(30, 15))
         results = t4(t3(t2(t1(self.data_info_ocr.copy()))))
         self.assertEqual(results['img'].shape, (15, 30, 3))
-        self.assertTrue(
-            np.allclose(results['gt_polygons'][0],
-                        self.data_info_ocr['gt_polygons'][0]))
-        self.assertTrue(
-            np.allclose(results['gt_polygons'][1],
-                        self.data_info_ocr['gt_polygons'][1]))
+        for i in range(2):
+            self.assertTrue(
+                poly2shapely(results['gt_polygons'][i]).equals(
+                    poly2shapely(self.data_info_ocr['gt_polygons'][i])))
         self.assertTrue(
             np.allclose(results['gt_bboxes'], self.data_info_ocr['gt_bboxes']))
-        self.assertEqual(results['gt_ignored'].all(),
-                         self.data_info_ocr['gt_ignored'].all())
+        self.assertTrue(
+            np.array_equal(results['gt_ignored'],
+                           self.data_info_ocr['gt_ignored']))
 
     def test_repr_det2ocr(self):
         transform = MMDet2MMOCR()

--- a/tests/test_datasets/test_transforms/test_ocr_transforms.py
+++ b/tests/test_datasets/test_transforms/test_ocr_transforms.py
@@ -247,6 +247,12 @@ class TestFixInvalidPolygon(unittest.TestCase):
                 np.array([0, 10, 0, 10, 10, 0, 0, 10]),
             ],
             gt_ignored=np.array([False, False], dtype=bool))
+        # no gt_polygons
+        self.data_info5 = dict(
+            img=np.random.random((30, 40, 3)),
+            gt_bboxes=np.array([[0., 0., 10., 10.], [0., 0., 10., 10.],
+                                [0, 0, 10, 10], [0, 0, 0, 0]]),
+            gt_ignored=np.array([False, False, False, False], dtype=bool))
 
     def test_transform_fix(self):
         transform = FixInvalidPolygon(mode='fix', min_poly_points=4)
@@ -278,6 +284,10 @@ class TestFixInvalidPolygon(unittest.TestCase):
         # and therefore the transform would return None
         results = transform(copy.deepcopy(self.data_info3))
         self.assertIsNone(results)
+        # If no gt_polygon inside
+        results = transform(copy.deepcopy(self.data_info5))
+        for k, v in results.items():
+            self.assertTrue(np.array_equal(v, self.data_info5[k]))
 
     def test_transform_ignore(self):
         transform = FixInvalidPolygon(mode='ignore')
@@ -293,13 +303,18 @@ class TestFixInvalidPolygon(unittest.TestCase):
                                  results['gt_ignored']):
             if not ignored:
                 self.assertTrue(poly2shapely(poly).is_valid)
+        # If no gt_polygon inside
+        results = transform(copy.deepcopy(self.data_info5))
+        for k, v in results.items():
+            self.assertTrue(np.array_equal(v, self.data_info5[k]))
 
     def test_repr(self):
         transform = FixInvalidPolygon()
         print(repr(transform))
         self.assertEqual(
             repr(transform),
-            'FixInvalidPolygon(mode = "fix", min_poly_points = 4)')
+            'FixInvalidPolygon(mode = "fix", min_poly_points = 4, '
+            'fix_from_bbox = True)')
 
 
 class TestRemoveIgnored(unittest.TestCase):

--- a/tests/test_datasets/test_transforms/test_ocr_transforms.py
+++ b/tests/test_datasets/test_transforms/test_ocr_transforms.py
@@ -264,6 +264,16 @@ class TestFixInvalidPolygon(unittest.TestCase):
             results['gt_polygons']) == len(self.data_info['gt_polygons']) - 1
         for poly in results['gt_polygons']:
             self.assertTrue(len(poly) >= 8 and len(poly) % 2 == 0)
+        # test not fixing the invalid polygons from bboxes
+        transform_wo_bbox = FixInvalidPolygon(
+            mode='fix', min_poly_points=4, fix_from_bbox=False)
+        results = transform_wo_bbox(copy.deepcopy(self.data_info2))
+        # The fourth one is removed because it is a line, and its bbox is also
+        # invalid
+        assert len(
+            results['gt_polygons']) == len(self.data_info['gt_polygons']) - 2
+        for poly in results['gt_polygons']:
+            self.assertTrue(len(poly) >= 8 and len(poly) % 2 == 0)
         # Fixing all invalid polygons would result in an empty result dict,
         # and therefore the transform would return None
         results = transform(copy.deepcopy(self.data_info3))

--- a/tests/test_datasets/test_transforms/test_textdet_transforms.py
+++ b/tests/test_datasets/test_transforms/test_textdet_transforms.py
@@ -5,10 +5,8 @@ import unittest.mock as mock
 
 import numpy as np
 from mmcv.transforms import Pad, RandomResize
-from parameterized import parameterized
 
-from mmocr.datasets.transforms import (BoundedScaleAspectJitter,
-                                       FixInvalidPolygon, RandomCrop,
+from mmocr.datasets.transforms import (BoundedScaleAspectJitter, RandomCrop,
                                        RandomFlip, Resize,
                                        ShortScaleAspectJitter, SourceImagePad,
                                        TextDetRandomCrop,
@@ -96,46 +94,6 @@ class TestEastRandomCrop(unittest.TestCase):
         self.assertEqual(pad_results['img'].shape, (30, 30, 3))
         self.assertEqual(pad_results['pad_shape'], (30, 30, 3))
         self.assertEqual(pad_results['img'].sum(), 15 * 30 * 3)
-
-
-class TestFixInvalidPolygon(unittest.TestCase):
-
-    def setUp(self):
-        self.data_info = dict(
-            img=np.random.random((30, 40, 3)),
-            gt_polygons=[
-                np.array([0., 0., 10., 10., 10., 0., 0., 10.]),
-                np.array([0., 0., 10., 0., 0., 10., 5., 10.])
-            ],
-            gt_ignored=np.array([False, False], dtype=bool))
-        for invalid_polys in self.data_info['gt_polygons']:
-            self.assertFalse(poly2shapely(invalid_polys).is_valid)
-        self.data_info2 = dict(
-            img=np.random.random((30, 40, 3)),
-            gt_polygons=[
-                np.array([0., 0., 10., 10., 10., 0.]),
-                np.array([0., 0., 10., 0., 0., 10.])
-            ],
-            gt_bboxes=np.array([[0., 0., 10., 10.], [0., 0., 10., 10.]]),
-            gt_ignored=np.array([False, False], dtype=bool))
-
-    @parameterized.expand([('fix'), ('ignore')])
-    def test_transform(self, mode):
-        transform = FixInvalidPolygon(mode=mode, min_poly_points=4)
-        results = transform(copy.deepcopy(self.data_info))
-        for poly, ignored in zip(results['gt_polygons'],
-                                 results['gt_ignored']):
-            if not ignored:
-                self.assertTrue(poly2shapely(poly).is_valid)
-        results = transform(copy.deepcopy(self.data_info2))
-        for poly, ignored in zip(results['gt_polygons'],
-                                 results['gt_ignored']):
-            self.assertTrue(len(poly) >= 8 and len(poly) % 2 == 0)
-
-    def test_repr(self):
-        transform = FixInvalidPolygon()
-        print(repr(transform))
-        self.assertEqual(repr(transform), 'FixInvalidPolygon(mode = "fix")')
 
 
 class TestRandomFlip(unittest.TestCase):

--- a/tests/test_datasets/test_transforms/test_wrappers.py
+++ b/tests/test_datasets/test_transforms/test_wrappers.py
@@ -61,7 +61,7 @@ class TestImgAug(unittest.TestCase):
     def test_transform(self):
 
         # Test empty transform
-        imgaug_transform = ImgAugWrapper()
+        imgaug_transform = ImgAugWrapper(fix_poly_trans=None)
         results = self._create_dummy_data()
         origin_results = copy.deepcopy(results)
         results = imgaug_transform(results)
@@ -72,7 +72,7 @@ class TestImgAug(unittest.TestCase):
                                  origin_results['gt_texts'])
 
         args = [dict(cls='Affine', translate_px=dict(x=-10, y=-10))]
-        imgaug_transform = ImgAugWrapper(args)
+        imgaug_transform = ImgAugWrapper(args, fix_poly_trans=None)
         results = self._create_dummy_data()
         results = imgaug_transform(results)
 
@@ -99,7 +99,7 @@ class TestImgAug(unittest.TestCase):
         label_target = np.array([0], dtype=np.int64)
         ignored = np.array([False], dtype=bool)
         texts = ['text1']
-        imgaug_transform = ImgAugWrapper(args)
+        imgaug_transform = ImgAugWrapper(args, fix_poly_trans=None)
         results = self._create_dummy_data()
         results = imgaug_transform(results)
         self.assert_result_equal(results, poly_target, box_target,
@@ -135,8 +135,8 @@ class TestImgAug(unittest.TestCase):
         print(repr(transform))
         self.assertEqual(
             repr(transform),
-            ("ImgAugWrapper(args = [['Resize', [0.5, 3.0]], ['Fliplr', 0.5]])"
-             ))
+            ("ImgAugWrapper(args = [['Resize', [0.5, 3.0]], ['Fliplr', 0.5]], "
+             "fix_poly_trans = {'type': 'FixInvalidPolygon'})"))
 
 
 class TestTorchVisionWrapper(unittest.TestCase):

--- a/tests/test_utils/test_polygon_utils.py
+++ b/tests/test_utils/test_polygon_utils.py
@@ -161,6 +161,12 @@ class TestPolygonUtils(unittest.TestCase):
         # invalid input
         with self.assertRaises(AssertionError):
             poly_make_valid([0, 0, 1, 1, 1, 0, 0, 1])
+        poly = Polygon([[337, 441], [326, 386], [334, 397], [342, 412],
+                        [296, 382], [317, 366], [324, 427], [315, 413],
+                        [308, 400], [349, 419], [337, 441]])
+        self.assertFalse(poly.is_valid)
+        poly = poly_make_valid(poly)
+        self.assertTrue(poly.is_valid)
 
     def test_poly_intersection(self):
 

--- a/tests/test_utils/test_transform_utils.py
+++ b/tests/test_utils/test_transform_utils.py
@@ -1,0 +1,41 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+import copy
+import unittest
+
+import numpy as np
+
+from mmocr.utils import remove_pipeline_elements
+
+
+class TestTransformUtils(unittest.TestCase):
+
+    def test_remove_pipeline_elements(self):
+        data = dict(img=np.random.random((30, 40, 3)))
+        results = remove_pipeline_elements(copy.deepcopy(data), [0, 1, 2])
+        self.assertTrue(np.array_equal(results['img'], data['img']))
+        self.assertEqual(len(data), len(results))
+
+        data['gt_polygons'] = [
+            np.array([0., 0., 10., 10., 10., 0.]),
+            np.array([0., 0., 10., 0., 0., 10.]),
+            np.array([0, 10, 0, 10, 1, 2, 3, 4]),
+            np.array([0, 10, 0, 10, 10, 0, 0, 10]),
+        ]
+        data['dummy'] = [
+            np.array([0., 0., 10., 10., 10., 0.]),
+        ]
+        data['gt_ignored'] = np.array([True, True, False, False], dtype=bool)
+        data['gt_bboxes_labels'] = np.array([0, 1, 2, 3])
+        data['gt_bboxes'] = np.array([[1, 2, 3, 4], [5, 6, 7, 8],
+                                      [0, 0, 10, 10], [0, 0, 0, 0]])
+        data['gt_texts'] = ['t1', 't2', 't3', 't4']
+        keys = [
+            'gt_polygons', 'gt_bboxes', 'gt_ignored', 'gt_texts',
+            'gt_bboxes_labels'
+        ]
+        results = remove_pipeline_elements(copy.deepcopy(data), [0, 1, 2])
+
+        for key in keys:
+            self.assertTrue(np.array_equal(results[key][0], data[key][3]))
+        self.assertTrue(np.array_equal(results['img'], data['img']))
+        self.assertTrue(np.array_equal(results['dummy'], data['dummy']))


### PR DESCRIPTION
Based on #1623.

## Motivation

1. There are a few more possible cases for invalid polygons which should be addressed in `FixInvalidPolygon`.
2. Some third-party augmentation libraries, such as ImgAug, may produce polygons not regarded as valid by `shapley`.
3. Sometimes there is a need to remove ignored instances from the pipeline. 

## Modifications

1. Enhance `FixInvalidPolygon` by tacking some corner cases which are usually seen in some datasets, and move it to `ocr_transforms.py` since it's general enough now.
2. Let `ImgAugWrapper` invokes `FixInvalidPolygon` to deal with some weird shape polygons by default.
3. Add `RemoveIgnored` transform to `ocr_transforms.py` as well.
4. Add `transform_utils.py` and implement `remove_pipeline_elements`.