### PR TITLE
[Fix] db_module_loss，negative number encountered in sqrt

### DIFF
--- a/mmocr/models/textdet/module_losses/db_module_loss.py
+++ b/mmocr/models/textdet/module_losses/db_module_loss.py
@@ -286,6 +286,8 @@ class DBModuleLoss(SegBasedModuleLoss):
         neg_cos_c = (
             (c_square - a_square - b_square) /
             (np.finfo(np.float32).eps + 2 * np.sqrt(a_square * b_square)))
+        # clip -cosC value to [-1, 1]
+        neg_cos_c = np.clip(neg_cos_c, -1.0, 1.0)
         # sinC^2=1-cosC^2
         square_sin = 1 - np.square(neg_cos_c)
         square_sin = np.nan_to_num(square_sin)


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation
训练自定义数据集时遇到RuntimeWarning如下
![image](https://user-images.githubusercontent.com/34083603/209079108-93d292e8-b778-42cb-bf09-64309ae84f97.png)
调试定位到出错原因如下：
由于pt1, pt2都是float32，计算a_square, b_square, c_square存在数值精度问题
导致后续根据余弦公式计算neg_cos_c时出现了小于-1或者大于1的情况
从而使得计算distance时sqrt下a_square * b_square * square_sin 出现负数
https://github.com/open-mmlab/mmocr/blob/24bfb1876808807e2cb595b31aea2ae9819e2ec0/mmocr/models/textdet/module_losses/db_module_loss.py#L278-L294

## Modification

解决方法：
将计算得到的neg_cos_c值进一步限制在[-1,1]间

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)
可以复现该问题的case
xs = [[0,1,2,...,35, 36], [0,1,2,...,35, 36],..., [0,1,2,...,35, 36], [0,1,2,...,35, 36],]，shape=(22，37)
ys = [[0,0,...,0,0], [1,1,...,1,1],..., [20,20,...,20,20], [21,21,...,21,21]]，shape=(22，37）
pt1 = array([4.8011017, 18.335022], dtype=float32)
pt2 = array([3.2233124, 7.532318], dtype=float32)

## Checklist

**Before PR**:

- [] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmocr/blob/main/.github/CONTRIBUTING.md) to create this PR.
- [] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmocr/blob/main/.github/CONTRIBUTING.md) are used to fix the potential lint issues.
- [] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with some of those projects.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
