### PR TITLE
Kevinnunu/add LMDBDumper and TextRecogLMDBConfigGenerator, update prepare_dataset.py script

### DIFF
--- a/mmocr/datasets/preparers/__init__.py
+++ b/mmocr/datasets/preparers/__init__.py
@@ -1,6 +1,7 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 from .config_generator import (TextDetConfigGenerator,
                                TextRecogConfigGenerator,
+                               TextRecogLMDBConfigGenerator,
                                TextSpottingConfigGenerator)
 from .data_converter import (TextDetDataConverter, TextRecogDataConverter,
                              TextSpottingDataConverter, WildReceiptConverter)
@@ -13,5 +14,6 @@ __all__ = [
     'DatasetPreparer', 'NaiveDataObtainer', 'TextDetDataConverter',
     'TextRecogDataConverter', 'TextSpottingDataConverter',
     'WildReceiptConverter', 'TextDetConfigGenerator',
-    'TextRecogConfigGenerator', 'TextSpottingConfigGenerator'
+    'TextRecogConfigGenerator', 'TextSpottingConfigGenerator',
+    'TextRecogLMDBConfigGenerator'
 ]

--- a/mmocr/datasets/preparers/config_generator.py
+++ b/mmocr/datasets/preparers/config_generator.py
@@ -318,6 +318,108 @@ class TextRecogConfigGenerator(BaseDatasetConfigGenerator):
 
 
 @CFG_GENERATORS.register_module()
+class TextRecogLMDBConfigGenerator(TextRecogConfigGenerator):
+    """Text recognition LMDB format dataset config generator.
+
+    Args:
+        data_root (str): The root path of the dataset.
+        dataset_name (str): The name of the dataset.
+        overwrite_cfg (bool): Whether to overwrite the dataset config file if
+            it already exists. If False, config generator will not generate new
+            config for datasets whose configs are already in base.
+        train_anns (List[Dict], optional): A list of train annotation files
+            to appear in the base configs. Defaults to
+            ``[dict(file='textrecog_train.lmdb'), dataset_postfix='']``.
+            Each element is typically a dict with the following fields:
+            - ann_file (str): The path to the annotation file relative to
+              data_root.
+            - dataset_postfix (str, optional): Affects the postfix of the
+              resulting variable in the generated config. If specified, the
+              dataset variable will be named in the form of
+              ``{dataset_name}_{dataset_postfix}_{task}_{split}``. Defaults to
+              None.
+        val_anns (List[Dict], optional): A list of val annotation files
+            to appear in the base configs, similar to ``train_anns``. Defaults
+            to [].
+        test_anns (List[Dict], optional): A list of test annotation files
+            to appear in the base configs, similar to ``train_anns``. Defaults
+            to ``[dict(file='textrecog_test.json')]``.
+        config_path (str): Path to the configs. Defaults to 'configs/'.
+
+    Example:
+        It generates a dataset config like:
+        >>> svt_textrecog_data_root = 'data/svt/'
+        >>> svt_textrecog_train = dict(
+        >>>     type='RecogLMDBDataset',
+        >>>     data_root=svt_textrecog_data_root,
+        >>>     ann_file='textrecog_train.lmdb',
+        >>>     pipeline=None)
+        >>> svt_textrecog_test = dict(
+        >>>     type='RecogLMDBDataset',
+        >>>     data_root=svt_textrecog_data_root,
+        >>>     ann_file='textrecog_test.lmdb',
+        >>>     test_mode=True,
+        >>>     pipeline=None)
+    """
+
+    def __init__(
+        self,
+        data_root: str,
+        dataset_name: str,
+        overwrite_cfg: bool = False,
+        train_anns: Optional[List[Dict]] = [
+            dict(ann_file='textrecog_train.lmdb', dataset_postfix='')
+        ],
+        val_anns: Optional[List[Dict]] = [],
+        test_anns: Optional[List[Dict]] = [
+            dict(ann_file='textrecog_test.lmdb', dataset_postfix='')
+        ],
+        config_path: str = 'configs/',
+    ) -> None:
+        super().__init__(
+            data_root=data_root,
+            dataset_name=dataset_name,
+            overwrite_cfg=overwrite_cfg,
+            train_anns=train_anns,
+            val_anns=val_anns,
+            test_anns=test_anns,
+            config_path=config_path)
+
+    def _gen_dataset_config(self) -> str:
+        """Generate a full dataset config based on the annotation file
+        dictionary.
+
+        Args:
+            ann_dict (dict[str, dict(str, str)]): A nested dictionary that maps
+                a config variable name (such as svt_textrecog_train) to
+                its corresponding annotation information dict. Each dict
+                contains following keys:
+                - ann_file (str): The path to the annotation file relative to
+                  data_root.
+                - dataset_postfix (str, optional): Affects the postfix of the
+                  resulting variable in the generated config. If specified, the
+                  dataset variable will be named in the form of
+                  ``{dataset_name}_{dataset_postfix}_{task}_{split}``. Defaults
+                  to None.
+                - split (str): The split the annotation belongs to. Usually
+                  it can be 'train', 'val' and 'test'.
+
+        Returns:
+            str: The generated dataset config.
+        """
+        cfg = ''
+        for key_name, ann_dict in self.anns.items():
+            cfg += f'\n{key_name} = dict(\n'
+            cfg += '    type=\'RecogLMDBDataset\',\n'
+            cfg += '    data_root=' + f'{self.dataset_name}_{self.task}_data_root,\n'  # noqa: E501
+            cfg += f'    ann_file=\'{ann_dict["ann_file"]}\',\n'
+            if ann_dict['split'] in ['test', 'val']:
+                cfg += '    test_mode=True,\n'
+            cfg += '    pipeline=None)\n'
+        return cfg
+
+
+@CFG_GENERATORS.register_module()
 class TextSpottingConfigGenerator(TextDetConfigGenerator):
     """Text spotting config generator.
 

--- a/mmocr/datasets/preparers/dumpers/__init__.py
+++ b/mmocr/datasets/preparers/dumpers/__init__.py
@@ -1,4 +1,4 @@
 # Copyright (c) OpenMMLab. All rights reserved.
-from .dumpers import JsonDumper, WildreceiptOpensetDumper
+from .dumpers import JsonDumper, WildreceiptOpensetDumper, LMDBDumper
 
-__all__ = ['JsonDumper', 'WildreceiptOpensetDumper']
+__all__ = ['JsonDumper', 'WildreceiptOpensetDumper', 'LMDBDumper']

--- a/mmocr/datasets/preparers/dumpers/dumpers.py
+++ b/mmocr/datasets/preparers/dumpers/dumpers.py
@@ -26,7 +26,7 @@ class JsonDumper:
 
         filename = f'{self.task}_{split}.json'
         dst_file = osp.join(data_root, filename)
-        mmengine.dump(data, dst_file)
+        mmengine.dump(data, dst_file, ensure_ascii=False)
 
 
 @DATA_DUMPERS.register_module()

--- a/mmocr/datasets/preparers/dumpers/dumpers.py
+++ b/mmocr/datasets/preparers/dumpers/dumpers.py
@@ -2,6 +2,11 @@
 import os.path as osp
 from typing import Dict, List
 
+import json
+import cv2
+import lmdb
+import numpy as np
+
 import mmengine
 
 from mmocr.utils import list_to_file
@@ -47,3 +52,124 @@ class WildreceiptOpensetDumper:
         filename = f'openset_{split}.txt'
         dst_file = osp.join(data_root, filename)
         list_to_file(dst_file, data)
+
+@DATA_DUMPERS.register_module()
+class LMDBDumper:
+
+    def __init__(self,
+                 task: str,
+                 label_only: bool = False,
+                 batch_size: int = 1000,
+                 encoding: str = 'utf-8',
+                 lmdb_map_size: int = 1099511627776,
+                 verify: bool = True) -> None:
+        assert task == 'textrecog', \
+            f'Using LMDBDumper task must be textrecog, but got {task}'
+        self.task = task
+        self.label_only = label_only
+        self.batch_size = batch_size
+        self.encoding = encoding
+        self.lmdb_map_size = lmdb_map_size
+        self.verify = verify
+    
+    def check_image_is_valid(self, imageBin):
+        if imageBin is None:
+            return False
+        imageBuf = np.frombuffer(imageBin, dtype=np.uint8)
+        img = cv2.imdecode(imageBuf, cv2.IMREAD_GRAYSCALE)
+        imgH, imgW = img.shape[0], img.shape[1]
+        if imgH * imgW == 0:
+            return False
+        return True
+    
+    def write_cache(self, env, cache):
+        with env.begin(write=True) as txn:
+            cursor = txn.cursor()
+            cursor.putmulti(cache, dupdata=False, overwrite=True)
+    
+    def parser_pack_instance(self, instance: Dict):
+        """parser an packed MMOCR format textrecog instance
+
+        Args:
+            instance (Dict): An packed MMOCR format textrecog instance.
+                For example,
+                {
+                    "instance": [
+                        {
+                            "text": "Hello"
+                        }
+                    ],
+                    "img_path": "img1.jpg"
+                }
+        """
+        assert isinstance(instance, Dict), 'Element of data_list must be a dict'
+        assert 'img_path' in instance and 'instances' in instance, \
+            'Element of data_list must have the following keys: img_path and instances,' \
+            f'but got {instance.keys()}'
+        assert isinstance(instance['instances'], List) and len(instance['instances']) == 1
+        assert 'text' in instance['instances'][0]
+
+        img_path = instance['img_path']
+        text = instance['instances'][0]['text']
+        return img_path, text
+
+    def dump(self, data: Dict, data_root: str, split: str) -> None:
+        """Dump data to LMDB format.
+
+        Args:
+            data (Dict): Data to be dumped.
+            data_root (str): Root directory of data.
+            split (str): Split of data.
+            cfg_path (str): Path to configs. Defaults to 'configs/'.
+        """
+
+        # create lmdb env
+        output_dirname = f'{self.task}_{split}.lmdb'
+        output = osp.join(data_root, output_dirname)
+        mmengine.mkdir_or_exist(output)
+        env = lmdb.open(output, map_size=self.lmdb_map_size)
+        # load data
+        if 'data_list' not in data:
+            raise ValueError('Dump data must have data_list key')
+        data_list = data['data_list']
+        cache = []
+        # index start from 1
+        cnt = 1
+        n_samples = len(data_list)
+        for d in data_list:
+            label_key = 'label-%09d'.encode(self.encoding) % cnt
+            img_name, text = self.parser_pack_instance(d)
+            if self.label_only:
+                # convert only labels to lmdb
+                line = json.dumps(
+                    dict(filename=img_name, text=text), ensure_ascii=False)
+                cache.append((label_key, line.encode(self.encoding)))
+            else:
+                # convert both images and labels to lmdb
+                img_path = osp.join(data_root, img_name)
+                if not osp.exists(img_path):
+                    print('%s does not exist' % img_path)
+                    continue
+                with open(img_path, 'rb') as f:
+                    image_bin = f.read()
+                if self.verify:
+                    try:
+                        if not self.check_image_is_valid(image_bin):
+                            print('%s is not a valid image' % img_path)
+                            continue
+                    except Exception:
+                        print('error occurred at ', img_name)
+                image_key = 'image-%09d'.encode(self.encoding) % cnt
+                cache.append((image_key, image_bin))
+                cache.append((label_key, text.encode(self.encoding)))
+            
+            if cnt % self.batch_size == 0:
+                self.write_cache(env, cache)
+                cache = []
+                print('Written %d / %d' % (cnt, n_samples))
+            cnt += 1
+        n_samples = cnt - 1
+        cache.append(
+            ('num-samples'.encode(self.encoding), str(n_samples).encode(self.encoding)))
+        self.write_cache(env, cache)
+        print('Created lmdb dataset with %d samples' % n_samples)

--- a/tools/dataset_converters/prepare_dataset.py
+++ b/tools/dataset_converters/prepare_dataset.py
@@ -23,6 +23,12 @@ def parse_args():
         help='Task type. Options are "textdet", "textrecog", "textspotting"'
         ' and "kie".')
     parser.add_argument(
+        '--lmdb',
+        action='store_true',
+        default=False,
+        help='Whether to dump the textrecog dataset to LMDB format.'
+        ' Only when --task=textrecog, this argument works')
+    parser.add_argument(
         '--overwrite-cfg',
         action='store_true',
         default=False,
@@ -39,6 +45,9 @@ def parse_args():
 
 def main():
     args = parse_args()
+    if args.lmdb and args.task != 'textrecog':
+        raise ValueError('Only textrecog task can use --lmdb.')
+
     register_all_modules()
     for dataset in args.datasets:
         if not osp.isdir(osp.join(args.dataset_zoo_path, dataset)):
@@ -50,6 +59,7 @@ def main():
             dataset_name=dataset,
             task=args.task,
             nproc=args.nproc,
+            dump_to_lmdb=args.lmdb,
             overwrite_cfg=args.overwrite_cfg)
         preparer()
 


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

增加LMDBDumper和TextRecogLMDBConfigGenerator，以配合RecogLMDBDataset和LoadImageFromLMDB使用

## Modification

1.tools/dataset_converters/prepare_dataset.py脚本增加--lmdb参数（仅textrecog任务支持），mmocr/datasets/preparers/data_preparer.py 的parser_cfg环节判断是否需要使用LMDB格式，完成对dataset_zoo中原始config的读取和更新，从而不需要人为手动修改原始config文件
2.mmocr/datasets/preparers/dumpers/dumpers.py 修复了JsonDumper输出文件无法正常显示中文的问题
3.mmocr/datasets/preparers/dumpers/dumpers.py 新增了LMDBDumper
4.mmocr/datasets/preparers/config_generator.py 新增TextRecogLMDBConfigGenerator，输出文件名以及内容中的dataset_name都会在原来的基础上加上'_lmdb‘后缀加以区分，举例如下：
<img width="1157" alt="image" src="https://user-images.githubusercontent.com/34083603/211998350-2f07556f-d12c-4a73-b951-e8c459e008c1.png">


## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

**Before PR**:

- [ ] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmocr/blob/main/.github/CONTRIBUTING.md) to create this PR.
- [ ] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmocr/blob/main/.github/CONTRIBUTING.md) are used to fix the potential lint issues.
- [ ] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with some of those projects.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
