### PR TITLE
[Fix] Explicitly create np object array for compatibility

### DIFF
--- a/mmocr/utils/polygon_utils.py
+++ b/mmocr/utils/polygon_utils.py
@@ -332,7 +332,7 @@ def offset_polygon(poly: ArrayLike, distance: float) -> ArrayLike:
     pco.AddPath(poly, pyclipper.JT_ROUND, pyclipper.ET_CLOSEDPOLYGON)
     # Returned result will be in type of int32, convert it back to float32
     # following MMOCR's convention
-    result = np.array(pco.Execute(distance))
+    result = np.array(pco.Execute(distance), dtype=object)
     if len(result) > 0 and isinstance(result[0], list):
         # The processed polygon has been split into several parts
         result = np.array([])


### PR DESCRIPTION
Addressing https://github.com/open-mmlab/mmocr/issues/1688

## Motivation

numpy has deprecated the usage of using `np.array` to create a ragged sequence without `dtype=object`.