### PR TITLE
[Enhancement] Revise upstream version limit

### DIFF
--- a/docs/en/get_started/install.md
+++ b/docs/en/get_started/install.md
@@ -193,6 +193,6 @@ MMOCR has different version requirements on MMEngine, MMCV and MMDetection at ea
 
 | MMOCR          | MMEngine                    | MMCV                       | MMDetection                 |
 | -------------- | --------------------------- | -------------------------- | --------------------------- |
-| dev-1.x        | 0.5.0 \<= mmengine \< 1.0.0 | 2.0.0rc4 \<= mmcv \< 2.1.0 | 3.0.0rc6 \<= mmdet \< 3.1.0 |
+| dev-1.x        | 0.5.0 \<= mmengine \< 1.0.0 | 2.0.0rc4 \<= mmcv \< 2.1.0 | 3.0.0rc0 \<= mmdet \< 3.1.0 |
 | 1.0.0rc\[4-5\] | 0.1.0 \<= mmengine \< 1.0.0 | 2.0.0rc1 \<= mmcv \< 2.1.0 | 3.0.0rc0 \<= mmdet \< 3.1.0 |
 | 1.0.0rc\[0-3\] | 0.0.0 \<= mmengine \< 0.2.0 | 2.0.0rc1 \<= mmcv \< 2.1.0 | 3.0.0rc0 \<= mmdet \< 3.1.0 |

--- a/docs/en/get_started/install.md
+++ b/docs/en/get_started/install.md
@@ -193,6 +193,6 @@ MMOCR has different version requirements on MMEngine, MMCV and MMDetection at ea
 
 | MMOCR          | MMEngine                    | MMCV                       | MMDetection                 |
 | -------------- | --------------------------- | -------------------------- | --------------------------- |
-| dev-1.x        | 0.1.0 \<= mmengine \< 1.0.0 | 2.0.0rc1 \<= mmcv \< 2.1.0 | 3.0.0rc0 \<= mmdet \< 3.1.0 |
+| dev-1.x        | 0.5.0 \<= mmengine \< 1.0.0 | 2.0.0rc4 \<= mmcv \< 2.1.0 | 3.0.0rc6 \<= mmdet \< 3.1.0 |
 | 1.0.0rc\[4-5\] | 0.1.0 \<= mmengine \< 1.0.0 | 2.0.0rc1 \<= mmcv \< 2.1.0 | 3.0.0rc0 \<= mmdet \< 3.1.0 |
 | 1.0.0rc\[0-3\] | 0.0.0 \<= mmengine \< 0.2.0 | 2.0.0rc1 \<= mmcv \< 2.1.0 | 3.0.0rc0 \<= mmdet \< 3.1.0 |

--- a/docs/zh_cn/get_started/install.md
+++ b/docs/zh_cn/get_started/install.md
@@ -194,6 +194,6 @@ docker run --gpus all --shm-size=8g -it -v {实际数据目录}:/mmocr/data mmoc
 
 | MMOCR          | MMEngine                    | MMCV                       | MMDetection                 |
 | -------------- | --------------------------- | -------------------------- | --------------------------- |
-| dev-1.x        | 0.5.0 \<= mmengine \< 1.0.0 | 2.0.0rc4 \<= mmcv \< 2.1.0 | 3.0.0rc6 \<= mmdet \< 3.1.0 |
+| dev-1.x        | 0.5.0 \<= mmengine \< 1.0.0 | 2.0.0rc4 \<= mmcv \< 2.1.0 | 3.0.0rc0 \<= mmdet \< 3.1.0 |
 | 1.0.0rc\[4-5\] | 0.1.0 \<= mmengine \< 1.0.0 | 2.0.0rc1 \<= mmcv \< 2.1.0 | 3.0.0rc0 \<= mmdet \< 3.1.0 |
 | 1.0.0rc\[0-3\] | 0.0.0 \<= mmengine \< 0.2.0 | 2.0.0rc1 \<= mmcv \< 2.1.0 | 3.0.0rc0 \<= mmdet \< 3.1.0 |

--- a/docs/zh_cn/get_started/install.md
+++ b/docs/zh_cn/get_started/install.md
@@ -194,6 +194,6 @@ docker run --gpus all --shm-size=8g -it -v {实际数据目录}:/mmocr/data mmoc
 
 | MMOCR          | MMEngine                    | MMCV                       | MMDetection                 |
 | -------------- | --------------------------- | -------------------------- | --------------------------- |
-| dev-1.x        | 0.1.0 \<= mmengine \< 1.0.0 | 2.0.0rc1 \<= mmcv \< 2.1.0 | 3.0.0rc0 \<= mmdet \< 3.1.0 |
+| dev-1.x        | 0.5.0 \<= mmengine \< 1.0.0 | 2.0.0rc4 \<= mmcv \< 2.1.0 | 3.0.0rc6 \<= mmdet \< 3.1.0 |
 | 1.0.0rc\[4-5\] | 0.1.0 \<= mmengine \< 1.0.0 | 2.0.0rc1 \<= mmcv \< 2.1.0 | 3.0.0rc0 \<= mmdet \< 3.1.0 |
 | 1.0.0rc\[0-3\] | 0.0.0 \<= mmengine \< 0.2.0 | 2.0.0rc1 \<= mmcv \< 2.1.0 | 3.0.0rc0 \<= mmdet \< 3.1.0 |

--- a/mmocr/__init__.py
+++ b/mmocr/__init__.py
@@ -41,7 +41,7 @@ assert (mmengine_version >= digit_version(mmengine_minimum_version)
     f'Please install mmengine>={mmengine_minimum_version}, ' \
     f'<{mmengine_maximum_version}.'
 
-mmdet_minimum_version = '3.0.0rc6'
+mmdet_minimum_version = '3.0.0rc0'
 mmdet_maximum_version = '3.1.0'
 mmdet_version = digit_version(mmdet.__version__)
 

--- a/mmocr/__init__.py
+++ b/mmocr/__init__.py
@@ -12,11 +12,11 @@ except ImportError:
 
 from .version import __version__, short_version
 
-mmcv_minimum_version = '2.0.0rc1'
+mmcv_minimum_version = '2.0.0rc4'
 mmcv_maximum_version = '2.1.0'
 mmcv_version = digit_version(mmcv.__version__)
 if mmengine is not None:
-    mmengine_minimum_version = '0.1.0'
+    mmengine_minimum_version = '0.5.0'
     mmengine_maximum_version = '1.0.0'
     mmengine_version = digit_version(mmengine.__version__)
 
@@ -41,7 +41,7 @@ assert (mmengine_version >= digit_version(mmengine_minimum_version)
     f'Please install mmengine>={mmengine_minimum_version}, ' \
     f'<{mmengine_maximum_version}.'
 
-mmdet_minimum_version = '3.0.0rc0'
+mmdet_minimum_version = '3.0.0rc6'
 mmdet_maximum_version = '3.1.0'
 mmdet_version = digit_version(mmdet.__version__)
 


### PR DESCRIPTION
Merge after https://github.com/open-mmlab/mmocr/pull/1608

## Motivation

ABCNet relies on `BezierAlign` in MMCV 2.0.0rc4, and the new inferencers rely on `BaseInferencer` in MMEngine 0.5.0.