### PR TITLE
[Fix] Fix textocr ignore flag

### DIFF
--- a/mmocr/datasets/preparers/parsers/coco_parser.py
+++ b/mmocr/datasets/preparers/parsers/coco_parser.py
@@ -90,12 +90,11 @@ class COCOTextDetAnnParser(BaseParser):
                             ignore=ann['legibility'] == 'illegible'))
                 elif self.variant == 'textocr':
                     # textocr use 'utf8_string' field to store the text and
-                    # the 'points' field to store the polygon, ignore flag
-                    # is not available.
+                    # the 'points' field to store the polygon, '.' is used to
+                    # represent the ignored text.
+                    text = ann.get('utf8_string', None)
                     instances.append(
                         dict(
-                            poly=ann['points'],
-                            text=ann.get('utf8_string', None),
-                            ignore=False))
+                            poly=ann['points'], text=text, ignore=text == '.'))
             samples.append((img_path, instances))
         return samples


### PR DESCRIPTION
The ignore flag of textocr was always set to `False`. However, this dataset indeed uses `'.'` to represent illegible or non-English texts.