### PR TITLE
[Feature] Support Multi-Scale Training for Text Detection

### DIFF
--- a/mmocr/models/textdet/module_losses/db_module_loss.py
+++ b/mmocr/models/textdet/module_losses/db_module_loss.py
@@ -240,7 +240,7 @@ class DBModuleLoss(SegBasedModuleLoss):
             if self._is_poly_invalid(polygon):
                 ignore_flags[idx] = True
         gt_shrink, ignore_flags = self._generate_kernels(
-            data_sample.img_shape,
+            data_sample.batch_input_shape,
             gt_instances.polygons,
             self.shrink_ratio,
             ignore_flags=ignore_flags)
@@ -249,9 +249,10 @@ class DBModuleLoss(SegBasedModuleLoss):
         gt_shrink = gt_shrink > 0
 
         gt_shrink_mask = self._generate_effective_mask(
-            data_sample.img_shape, gt_instances[ignore_flags].polygons)
+            data_sample.batch_input_shape, gt_instances[ignore_flags].polygons)
         gt_thr, gt_thr_mask = self._generate_thr_map(
-            data_sample.img_shape, gt_instances[~ignore_flags].polygons)
+            data_sample.batch_input_shape,
+            gt_instances[~ignore_flags].polygons)
 
         # to_tensor
         gt_shrink = torch.from_numpy(gt_shrink).unsqueeze(0).float()

--- a/mmocr/models/textdet/module_losses/drrg_module_loss.py
+++ b/mmocr/models/textdet/module_losses/drrg_module_loss.py
@@ -282,7 +282,7 @@ class DRRGModuleLoss(TextSnakeModuleLoss):
 
         polygons = gt_instances[~ignore_flags].polygons
         ignored_polygons = gt_instances[ignore_flags].polygons
-        h, w = data_sample.img_shape
+        h, w = data_sample.batch_input_shape
 
         gt_text_mask = self._generate_text_region_mask((h, w), polygons)
         gt_mask = self._generate_effective_mask((h, w), ignored_polygons)

--- a/mmocr/models/textdet/module_losses/fce_module_loss.py
+++ b/mmocr/models/textdet/module_losses/fce_module_loss.py
@@ -211,7 +211,7 @@ class FCEModuleLoss(TextSnakeModuleLoss):
             tuple[Tensor]: A tuple of three tensors from three different
             feature level as the targets of one prediction.
         """
-        img_size = data_sample.img_shape[:2]
+        img_size = data_sample.batch_input_shape[:2]
         text_polys = data_sample.gt_instances.polygons
         ignore_flags = data_sample.gt_instances.ignored
 

--- a/mmocr/models/textdet/module_losses/pan_module_loss.py
+++ b/mmocr/models/textdet/module_losses/pan_module_loss.py
@@ -157,14 +157,14 @@ class PANModuleLoss(SegBasedModuleLoss):
         for ratio in self.shrink_ratio:
             # TODO pass `gt_ignored` to `_generate_kernels`
             gt_kernel, _ = self._generate_kernels(
-                data_sample.img_shape,
+                data_sample.batch_input_shape,
                 gt_polygons,
                 ratio,
                 ignore_flags=None,
                 max_shrink_dist=self.max_shrink_dist)
             gt_kernels.append(gt_kernel)
         gt_polygons_ignored = data_sample.gt_instances[gt_ignored].polygons
-        gt_mask = self._generate_effective_mask(data_sample.img_shape,
+        gt_mask = self._generate_effective_mask(data_sample.batch_input_shape,
                                                 gt_polygons_ignored)
 
         gt_kernels = np.stack(gt_kernels, axis=0)

--- a/mmocr/models/textdet/module_losses/textsnake_module_loss.py
+++ b/mmocr/models/textdet/module_losses/textsnake_module_loss.py
@@ -203,14 +203,14 @@ class TextSnakeModuleLoss(SegBasedModuleLoss):
         polygons = gt_instances[~ignore_flags].polygons
         ignored_polygons = gt_instances[ignore_flags].polygons
 
-        gt_text_mask = self._generate_text_region_mask(data_sample.img_shape,
-                                                       polygons)
-        gt_mask = self._generate_effective_mask(data_sample.img_shape,
+        gt_text_mask = self._generate_text_region_mask(
+            data_sample.batch_input_shape, polygons)
+        gt_mask = self._generate_effective_mask(data_sample.batch_input_shape,
                                                 ignored_polygons)
 
         (gt_center_region_mask, gt_radius_map, gt_sin_map,
          gt_cos_map) = self._generate_center_mask_attrib_maps(
-             data_sample.img_shape, polygons)
+             data_sample.batch_input_shape, polygons)
 
         return (gt_text_mask, gt_mask, gt_center_region_mask, gt_radius_map,
                 gt_sin_map, gt_cos_map)


### PR DESCRIPTION
Multiscale training is an attractive trick for text detection since the scale of text is highly variable.

Supporting multi-scale training is simple, we only need to modify the generation of text target to use `data_sample.batch_input_shape` instead of `data_sample.img_shape`. This modification will not affect the existing detectors in mmocr, because their input size is fixed, i.e. `data_sample.img_shape=data_sample.batch_input_shape.`

To use multi-scale training, here is a simple config
```python
train_pipeline = [
    dict(type='LoadImageFromFile', color_type='color_ignore_orientation'),
    dict(
        type='LoadOCRAnnotations',
        with_bbox=True,
        with_polygon=True,
        with_label=True,
    ),
    dict(
        type='RandomResize',
        scale=[(1280, 800), (1280, 1024)],
        keep_ratio=True),
    dict(
        type='PackTextDetInputs',
        meta_keys=('img_path', 'ori_shape', 'img_shape'))
]
```