### PR TITLE
[Feature] Support batch augmentation through BatchAugSampler

### DIFF
--- a/docs/en/api/datasets.rst
+++ b/docs/en/api/datasets.rst
@@ -9,6 +9,18 @@ mmocr.datasets
    :local:
    :backlinks: top
 
+.. currentmodule:: mmocr.datasets.samplers
+
+Samplers
+---------------------------------------------
+
+.. autosummary::
+   :toctree: generated
+   :nosignatures:
+   :template: classtemplate.rst
+
+   BatchAugSampler
+
 .. currentmodule:: mmocr.datasets
 
 Datasets

--- a/docs/zh_cn/api/datasets.rst
+++ b/docs/zh_cn/api/datasets.rst
@@ -9,6 +9,18 @@ mmocr.datasets
    :local:
    :backlinks: top
 
+.. currentmodule:: mmocr.datasets.samplers
+
+Samplers
+---------------------------------------------
+
+.. autosummary::
+   :toctree: generated
+   :nosignatures:
+   :template: classtemplate.rst
+
+   BatchAugSampler
+
 .. currentmodule:: mmocr.datasets
 
 Datasets

--- a/mmocr/datasets/samplers/__init__.py
+++ b/mmocr/datasets/samplers/__init__.py
@@ -1,4 +1,4 @@
 # Copyright (c) OpenMMLab. All rights reserved.
-from .repeat_aug import RepeatAugSampler
+from .batch_aug import BatchAugSampler
 
-__all__ = ['RepeatAugSampler']
+__all__ = ['BatchAugSampler']

--- a/tests/test_datasets/test_samplers/test_batch_aug.py
+++ b/tests/test_datasets/test_samplers/test_batch_aug.py
@@ -1,15 +1,14 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 
-import math
 from unittest import TestCase
 from unittest.mock import patch
 
 import torch
 from mmengine.logging import MMLogger
 
-from mmocr.datasets import RepeatAugSampler
+from mmocr.datasets import BatchAugSampler
 
-file = 'mmocr.datasets.samplers.repeat_aug.'
+file = 'mmocr.datasets.samplers.batch_aug.'
 
 
 class MockDist:
@@ -28,7 +27,7 @@ class MockDist:
         return self.dist_info[0] == 0
 
 
-class TestRepeatAugSampler(TestCase):
+class TestBatchAugSampler(TestCase):
 
     def setUp(self):
         self.data_length = 100
@@ -36,63 +35,51 @@ class TestRepeatAugSampler(TestCase):
 
     @patch(file + 'get_dist_info', return_value=(0, 1))
     def test_non_dist(self, mock):
-        sampler = RepeatAugSampler(self.dataset, num_repeats=3, shuffle=False)
+        sampler = BatchAugSampler(self.dataset, num_repeats=3, shuffle=False)
         self.assertEqual(sampler.world_size, 1)
         self.assertEqual(sampler.rank, 0)
         self.assertEqual(sampler.total_size, self.data_length * 3)
         self.assertEqual(sampler.num_samples, self.data_length * 3)
-        self.assertEqual(sampler.num_selected_samples, self.data_length)
-        self.assertEqual(len(sampler), sampler.num_selected_samples)
         indices = [x for x in range(self.data_length) for _ in range(3)]
-        self.assertEqual(list(sampler), indices[:self.data_length])
-
-        logger = MMLogger.get_current_instance()
-        with self.assertLogs(logger, 'WARN') as log:
-            sampler = RepeatAugSampler(self.dataset, shuffle=False)
-        self.assertIn('always picks a fixed part', log.output[0])
+        self.assertEqual(list(sampler), indices)
 
     @patch(file + 'get_dist_info', return_value=(2, 3))
-    @patch(file + 'is_main_process', return_value=False)
-    def test_dist(self, mock1, mock2):
-        sampler = RepeatAugSampler(self.dataset, num_repeats=3, shuffle=False)
+    def test_dist(self, mock):
+        sampler = BatchAugSampler(self.dataset, num_repeats=3, shuffle=False)
         self.assertEqual(sampler.world_size, 3)
         self.assertEqual(sampler.rank, 2)
         self.assertEqual(sampler.num_samples, self.data_length)
         self.assertEqual(sampler.total_size, self.data_length * 3)
-        self.assertEqual(sampler.num_selected_samples,
-                         math.ceil(self.data_length / 3))
-        self.assertEqual(len(sampler), sampler.num_selected_samples)
-        indices = [x for x in range(self.data_length) for _ in range(3)]
-        self.assertEqual(
-            list(sampler), indices[2::3][:sampler.num_selected_samples])
 
         logger = MMLogger.get_current_instance()
         with patch.object(logger, 'warning') as mock_log:
-            sampler = RepeatAugSampler(self.dataset, shuffle=False)
+            sampler = BatchAugSampler(self.dataset, shuffle=False)
             mock_log.assert_not_called()
 
     @patch(file + 'get_dist_info', return_value=(0, 1))
     @patch(file + 'sync_random_seed', return_value=7)
     def test_shuffle(self, mock1, mock2):
         # test seed=None
-        sampler = RepeatAugSampler(self.dataset, seed=None)
+        sampler = BatchAugSampler(self.dataset, seed=None)
         self.assertEqual(sampler.seed, 7)
 
         # test random seed
-        sampler = RepeatAugSampler(self.dataset, shuffle=True, seed=0)
+        sampler = BatchAugSampler(self.dataset, shuffle=True, seed=0)
         sampler.set_epoch(10)
         g = torch.Generator()
         g.manual_seed(10)
-        indices = torch.randperm(len(self.dataset), generator=g).tolist()
-        indices = [x for x in indices
-                   for _ in range(3)][:sampler.num_selected_samples]
+        indices = [
+            x for x in torch.randperm(len(self.dataset), generator=g)
+            for _ in range(3)
+        ]
         self.assertEqual(list(sampler), indices)
 
-        sampler = RepeatAugSampler(self.dataset, shuffle=True, seed=42)
+        sampler = BatchAugSampler(self.dataset, shuffle=True, seed=42)
         sampler.set_epoch(10)
         g = torch.Generator()
         g.manual_seed(42 + 10)
-        indices = torch.randperm(len(self.dataset), generator=g).tolist()
-        indices = [x for x in indices
-                   for _ in range(3)][:sampler.num_selected_samples]
+        indices = [
+            x for x in torch.randperm(len(self.dataset), generator=g)
+            for _ in range(3)
+        ]
         self.assertEqual(list(sampler), indices)


### PR DESCRIPTION
## Motivation

[Batch augmentation](https://openaccess.thecvf.com/content_CVPR_2020/papers/Hoffer_Augment_Your_Batch_Improving_Generalization_Through_Instance_Repetition_CVPR_2020_paper.pdf) is a trick that improves the model's generalization ability. It's done by repeating the same data instance for several times and let each of them goes through parallel data augmentations in a single batch.

In MMOCR, the same effect can be achieved by using `BatchAugSampler`, which generates the same index for `num_repeat` times consecutively. And the final "dataset length" will be `num_repeat` times the original dataset length. 

That is, a dataset comprising of `[0, 1, 2, 3]` may be randomly shuffled and sampled by `BatchAugSampler` and what dataloader finally gets could be `[2, 2, 1, 1, 0, 0, 3, 3]` when `num_repeats=2`.

**It's also important to make batch size divisible by `num_repeats`**, otherwise the repeated elements are not necessarily placed in the same batch.

## Usage
1. Replace sampler in `train_dataloader` with `BatchAugSampler`, and specify `num_repeats`
2. Update batch size in `train_dataloader`, which should be divisible by `num_repeats`, e.g.

```python
train_dataloader = dict(
    batch_size=4,
    sampler=dict(type='RepeatAugSampler', shuffle=True, num_repeats=2),
)
```