### PR TITLE
[Enhancement] Deprecate file_client_args and use backend_args instead

### DIFF
--- a/configs/textdet/dbnet/_base_dbnet_resnet18_fpnc.py
+++ b/configs/textdet/dbnet/_base_dbnet_resnet18_fpnc.py
@@ -1,5 +1,3 @@
-file_client_args = dict(backend='disk')
-
 model = dict(
     type='DBNet',
     backbone=dict(
@@ -27,10 +25,7 @@ model = dict(
         pad_size_divisor=32))
 
 train_pipeline = [
-    dict(
-        type='LoadImageFromFile',
-        file_client_args=file_client_args,
-        color_type='color_ignore_orientation'),
+    dict(type='LoadImageFromFile', color_type='color_ignore_orientation'),
     dict(
         type='LoadOCRAnnotations',
         with_polygon=True,
@@ -55,10 +50,7 @@ train_pipeline = [
 ]
 
 test_pipeline = [
-    dict(
-        type='LoadImageFromFile',
-        file_client_args=file_client_args,
-        color_type='color_ignore_orientation'),
+    dict(type='LoadImageFromFile', color_type='color_ignore_orientation'),
     dict(type='Resize', scale=(1333, 736), keep_ratio=True),
     dict(
         type='LoadOCRAnnotations',

--- a/configs/textdet/dbnet/_base_dbnet_resnet50-dcnv2_fpnc.py
+++ b/configs/textdet/dbnet/_base_dbnet_resnet50-dcnv2_fpnc.py
@@ -1,5 +1,3 @@
-file_client_args = dict(backend='disk')
-
 model = dict(
     type='DBNet',
     backbone=dict(
@@ -29,10 +27,7 @@ model = dict(
         pad_size_divisor=32))
 
 train_pipeline = [
-    dict(
-        type='LoadImageFromFile',
-        file_client_args=file_client_args,
-        color_type='color_ignore_orientation'),
+    dict(type='LoadImageFromFile', color_type='color_ignore_orientation'),
     dict(
         type='LoadOCRAnnotations',
         with_bbox=True,
@@ -57,10 +52,7 @@ train_pipeline = [
 ]
 
 test_pipeline = [
-    dict(
-        type='LoadImageFromFile',
-        file_client_args=file_client_args,
-        color_type='color_ignore_orientation'),
+    dict(type='LoadImageFromFile', color_type='color_ignore_orientation'),
     dict(type='Resize', scale=(4068, 1024), keep_ratio=True),
     dict(
         type='LoadOCRAnnotations',

--- a/configs/textdet/dbnet/dbnet_resnet18_fpnc_100k_synthtext.py
+++ b/configs/textdet/dbnet/dbnet_resnet18_fpnc_100k_synthtext.py
@@ -5,13 +5,8 @@ _base_ = [
     '../_base_/schedules/schedule_sgd_100k.py',
 ]
 
-file_client_args = dict(backend='disk')
-
 train_pipeline = [
-    dict(
-        type='LoadImageFromFile',
-        file_client_args=file_client_args,
-        color_type='color_ignore_orientation'),
+    dict(type='LoadImageFromFile', color_type='color_ignore_orientation'),
     dict(
         type='LoadOCRAnnotations',
         with_polygon=True,

--- a/configs/textdet/dbnet/dbnet_resnet18_fpnc_1200e_totaltext.py
+++ b/configs/textdet/dbnet/dbnet_resnet18_fpnc_1200e_totaltext.py
@@ -5,13 +5,8 @@ _base_ = [
     '../_base_/schedules/schedule_sgd_1200e.py',
 ]
 
-file_client_args = dict(backend='disk')
-
 train_pipeline = [
-    dict(
-        type='LoadImageFromFile',
-        file_client_args=file_client_args,
-        color_type='color_ignore_orientation'),
+    dict(type='LoadImageFromFile', color_type='color_ignore_orientation'),
     dict(
         type='LoadOCRAnnotations',
         with_polygon=True,
@@ -37,10 +32,7 @@ train_pipeline = [
 ]
 
 test_pipeline = [
-    dict(
-        type='LoadImageFromFile',
-        file_client_args=file_client_args,
-        color_type='color_ignore_orientation'),
+    dict(type='LoadImageFromFile', color_type='color_ignore_orientation'),
     dict(type='Resize', scale=(1333, 736), keep_ratio=True),
     dict(
         type='LoadOCRAnnotations',

--- a/configs/textdet/drrg/_base_drrg_resnet50_fpn-unet.py
+++ b/configs/textdet/drrg/_base_drrg_resnet50_fpn-unet.py
@@ -1,5 +1,3 @@
-file_client_args = dict(backend='disk')
-
 model = dict(
     type='DRRG',
     backbone=dict(
@@ -29,10 +27,7 @@ model = dict(
         pad_size_divisor=32))
 
 train_pipeline = [
-    dict(
-        type='LoadImageFromFile',
-        file_client_args=file_client_args,
-        color_type='color_ignore_orientation'),
+    dict(type='LoadImageFromFile', color_type='color_ignore_orientation'),
     dict(
         type='LoadOCRAnnotations',
         with_bbox=True,
@@ -82,10 +77,7 @@ train_pipeline = [
 ]
 
 test_pipeline = [
-    dict(
-        type='LoadImageFromFile',
-        file_client_args=file_client_args,
-        color_type='color_ignore_orientation'),
+    dict(type='LoadImageFromFile', color_type='color_ignore_orientation'),
     dict(type='Resize', scale=(1024, 640), keep_ratio=True),
     # add loading annotation after ``Resize`` because ground truth
     # does not need to do resize data transform

--- a/configs/textdet/fcenet/_base_fcenet_resnet50_fpn.py
+++ b/configs/textdet/fcenet/_base_fcenet_resnet50_fpn.py
@@ -1,5 +1,3 @@
-file_client_args = dict(backend='disk')
-
 model = dict(
     type='FCENet',
     backbone=dict(
@@ -41,10 +39,7 @@ model = dict(
         pad_size_divisor=32))
 
 train_pipeline = [
-    dict(
-        type='LoadImageFromFile',
-        file_client_args=file_client_args,
-        color_type='color_ignore_orientation'),
+    dict(type='LoadImageFromFile', color_type='color_ignore_orientation'),
     dict(
         type='LoadOCRAnnotations',
         with_polygon=True,
@@ -96,10 +91,7 @@ train_pipeline = [
 ]
 
 test_pipeline = [
-    dict(
-        type='LoadImageFromFile',
-        file_client_args=file_client_args,
-        color_type='color_ignore_orientation'),
+    dict(type='LoadImageFromFile', color_type='color_ignore_orientation'),
     dict(type='Resize', scale=(2260, 2260), keep_ratio=True),
     # add loading annotation after ``Resize`` because ground truth
     # does not need to do resize data transform

--- a/configs/textdet/fcenet/fcenet_resnet50-dcnv2_fpn_1500e_ctw1500.py
+++ b/configs/textdet/fcenet/fcenet_resnet50-dcnv2_fpn_1500e_ctw1500.py
@@ -12,17 +12,13 @@ param_scheduler = [
     dict(type='PolyLR', power=0.9, eta_min=1e-7, end=1500),
 ]
 
-file_client_args = dict(backend='disk')
 # dataset settings
 ctw1500_textdet_train = _base_.ctw1500_textdet_train
 ctw1500_textdet_test = _base_.ctw1500_textdet_test
 
 # test pipeline for CTW1500
 ctw_test_pipeline = [
-    dict(
-        type='LoadImageFromFile',
-        file_client_args=file_client_args,
-        color_type='color_ignore_orientation'),
+    dict(type='LoadImageFromFile', color_type='color_ignore_orientation'),
     dict(type='Resize', scale=(1080, 736), keep_ratio=True),
     # add loading annotation after ``Resize`` because ground truth
     # does not need to do resize data transform

--- a/configs/textdet/maskrcnn/_base_mask-rcnn_resnet50_fpn.py
+++ b/configs/textdet/maskrcnn/_base_mask-rcnn_resnet50_fpn.py
@@ -1,7 +1,5 @@
 _base_ = ['mmdet::_base_/models/mask-rcnn_r50_fpn.py']
 
-file_client_args = dict(backend='disk')
-
 mask_rcnn = _base_.pop('model')
 # Adapt Mask R-CNN model to OCR task
 mask_rcnn.update(
@@ -18,10 +16,7 @@ mask_rcnn.update(
 model = dict(type='MMDetWrapper', text_repr_type='poly', cfg=mask_rcnn)
 
 train_pipeline = [
-    dict(
-        type='LoadImageFromFile',
-        file_client_args=file_client_args,
-        color_type='color_ignore_orientation'),
+    dict(type='LoadImageFromFile', color_type='color_ignore_orientation'),
     dict(
         type='LoadOCRAnnotations',
         with_polygon=True,
@@ -49,10 +44,7 @@ train_pipeline = [
 ]
 
 test_pipeline = [
-    dict(
-        type='LoadImageFromFile',
-        file_client_args=file_client_args,
-        color_type='color_ignore_orientation'),
+    dict(type='LoadImageFromFile', color_type='color_ignore_orientation'),
     dict(type='Resize', scale=(1920, 1920), keep_ratio=True),
     dict(
         type='LoadOCRAnnotations',

--- a/configs/textdet/maskrcnn/mask-rcnn_resnet50_fpn_160e_ctw1500.py
+++ b/configs/textdet/maskrcnn/mask-rcnn_resnet50_fpn_160e_ctw1500.py
@@ -20,10 +20,7 @@ ctw1500_textdet_test = _base_.ctw1500_textdet_test
 
 # test pipeline for CTW1500
 ctw_test_pipeline = [
-    dict(
-        type='LoadImageFromFile',
-        file_client_args=dict(backend='disk'),
-        color_type='color_ignore_orientation'),
+    dict(type='LoadImageFromFile', color_type='color_ignore_orientation'),
     dict(type='Resize', scale=(1600, 1600), keep_ratio=True),
     # add loading annotation after ``Resize`` because ground truth
     # does not need to do resize data transform

--- a/configs/textdet/panet/_base_panet_resnet18_fpem-ffm.py
+++ b/configs/textdet/panet/_base_panet_resnet18_fpem-ffm.py
@@ -32,12 +32,8 @@ model = dict(
         ),
         postprocessor=dict(type='PANPostprocessor', text_repr_type='quad')))
 
-file_client_args = dict(backend='disk')
 train_pipeline = [
-    dict(
-        type='LoadImageFromFile',
-        file_client_args=file_client_args,
-        color_type='color_ignore_orientation'),
+    dict(type='LoadImageFromFile', color_type='color_ignore_orientation'),
     dict(
         type='LoadOCRAnnotations',
         with_polygon=True,
@@ -60,10 +56,7 @@ train_pipeline = [
 ]
 
 test_pipeline = [
-    dict(
-        type='LoadImageFromFile',
-        file_client_args=file_client_args,
-        color_type='color_ignore_orientation'),
+    dict(type='LoadImageFromFile', color_type='color_ignore_orientation'),
     # TODO Replace with mmcv.RescaleToShort when it's ready
     dict(
         type='ShortScaleAspectJitter',

--- a/configs/textdet/panet/panet_resnet18_fpem-ffm_600e_ctw1500.py
+++ b/configs/textdet/panet/panet_resnet18_fpem-ffm_600e_ctw1500.py
@@ -9,12 +9,8 @@ model = dict(det_head=dict(module_loss=dict(shrink_ratio=(1, 0.7))))
 
 default_hooks = dict(checkpoint=dict(type='CheckpointHook', interval=20), )
 
-file_client_args = dict(backend='disk')
 train_pipeline = [
-    dict(
-        type='LoadImageFromFile',
-        file_client_args=file_client_args,
-        color_type='color_ignore_orientation'),
+    dict(type='LoadImageFromFile', color_type='color_ignore_orientation'),
     dict(
         type='LoadOCRAnnotations',
         with_polygon=True,
@@ -37,10 +33,7 @@ train_pipeline = [
 ]
 
 test_pipeline = [
-    dict(
-        type='LoadImageFromFile',
-        file_client_args=file_client_args,
-        color_type='color_ignore_orientation'),
+    dict(type='LoadImageFromFile', color_type='color_ignore_orientation'),
     # TODO Replace with mmcv.RescaleToShort when it's ready
     dict(
         type='ShortScaleAspectJitter',

--- a/configs/textdet/panet/panet_resnet50_fpem-ffm_600e_icdar2017.py
+++ b/configs/textdet/panet/panet_resnet50_fpem-ffm_600e_icdar2017.py
@@ -7,12 +7,8 @@ _base_ = [
 
 default_hooks = dict(checkpoint=dict(type='CheckpointHook', interval=20), )
 
-file_client_args = dict(backend='disk')
 train_pipeline = [
-    dict(
-        type='LoadImageFromFile',
-        file_client_args=file_client_args,
-        color_type='color_ignore_orientation'),
+    dict(type='LoadImageFromFile', color_type='color_ignore_orientation'),
     dict(
         type='LoadOCRAnnotations',
         with_polygon=True,
@@ -35,10 +31,7 @@ train_pipeline = [
 ]
 
 test_pipeline = [
-    dict(
-        type='LoadImageFromFile',
-        file_client_args=file_client_args,
-        color_type='color_ignore_orientation'),
+    dict(type='LoadImageFromFile', color_type='color_ignore_orientation'),
     # TODO Replace with mmcv.RescaleToShort when it's ready
     dict(
         type='ShortScaleAspectJitter',

--- a/configs/textdet/psenet/_base_psenet_resnet50_fpnf.py
+++ b/configs/textdet/psenet/_base_psenet_resnet50_fpnf.py
@@ -1,5 +1,3 @@
-file_client_args = dict(backend='disk')
-
 model = dict(
     type='PSENet',
     backbone=dict(
@@ -32,10 +30,7 @@ model = dict(
         pad_size_divisor=32))
 
 train_pipeline = [
-    dict(
-        type='LoadImageFromFile',
-        file_client_args=file_client_args,
-        color_type='color_ignore_orientation'),
+    dict(type='LoadImageFromFile', color_type='color_ignore_orientation'),
     dict(
         type='LoadOCRAnnotations',
         with_polygon=True,
@@ -58,10 +53,7 @@ train_pipeline = [
 ]
 
 test_pipeline = [
-    dict(
-        type='LoadImageFromFile',
-        file_client_args=file_client_args,
-        color_type='color_ignore_orientation'),
+    dict(type='LoadImageFromFile', color_type='color_ignore_orientation'),
     dict(type='Resize', scale=(2240, 2240), keep_ratio=True),
     dict(
         type='LoadOCRAnnotations',

--- a/configs/textdet/psenet/psenet_resnet50_fpnf_600e_ctw1500.py
+++ b/configs/textdet/psenet/psenet_resnet50_fpnf_600e_ctw1500.py
@@ -17,10 +17,7 @@ ctw1500_textdet_train = _base_.ctw1500_textdet_train
 ctw1500_textdet_test = _base_.ctw1500_textdet_test
 
 test_pipeline_ctw = [
-    dict(
-        type='LoadImageFromFile',
-        file_client_args=_base_.file_client_args,
-        color_type='color_ignore_orientation'),
+    dict(type='LoadImageFromFile', color_type='color_ignore_orientation'),
     dict(type='Resize', scale=(1280, 1280), keep_ratio=True),
     dict(
         type='LoadOCRAnnotations',

--- a/configs/textdet/textsnake/_base_textsnake_resnet50_fpn-unet.py
+++ b/configs/textdet/textsnake/_base_textsnake_resnet50_fpn-unet.py
@@ -1,5 +1,3 @@
-file_client_args = dict(backend='disk')
-
 model = dict(
     type='TextSnake',
     backbone=dict(
@@ -28,10 +26,7 @@ model = dict(
         pad_size_divisor=32))
 
 train_pipeline = [
-    dict(
-        type='LoadImageFromFile',
-        file_client_args=file_client_args,
-        color_type='color_ignore_orientation'),
+    dict(type='LoadImageFromFile', color_type='color_ignore_orientation'),
     dict(
         type='LoadOCRAnnotations',
         with_bbox=True,
@@ -72,10 +67,7 @@ train_pipeline = [
 ]
 
 test_pipeline = [
-    dict(
-        type='LoadImageFromFile',
-        file_client_args=file_client_args,
-        color_type='color_ignore_orientation'),
+    dict(type='LoadImageFromFile', color_type='color_ignore_orientation'),
     dict(type='Resize', scale=(1333, 736), keep_ratio=True),
     # add loading annotation after ``Resize`` because ground truth
     # does not need to do resize data transform

--- a/configs/textrecog/abinet/_base_abinet-vision.py
+++ b/configs/textrecog/abinet/_base_abinet-vision.py
@@ -39,14 +39,8 @@ model = dict(
         mean=[123.675, 116.28, 103.53],
         std=[58.395, 57.12, 57.375]))
 
-file_client_args = dict(backend='disk')
-
 train_pipeline = [
-    dict(
-        type='LoadImageFromFile',
-        file_client_args=file_client_args,
-        ignore_empty=True,
-        min_size=2),
+    dict(type='LoadImageFromFile', ignore_empty=True, min_size=2),
     dict(type='LoadOCRAnnotations', with_text=True),
     dict(type='Resize', scale=(128, 32)),
     dict(
@@ -107,7 +101,7 @@ train_pipeline = [
 ]
 
 test_pipeline = [
-    dict(type='LoadImageFromFile', file_client_args=file_client_args),
+    dict(type='LoadImageFromFile'),
     dict(type='Resize', scale=(128, 32)),
     # add loading annotation after ``Resize`` because ground truth
     # does not need to do resize data transform
@@ -118,7 +112,7 @@ test_pipeline = [
 ]
 
 tta_pipeline = [
-    dict(type='LoadImageFromFile', file_client_args=file_client_args),
+    dict(type='LoadImageFromFile'),
     dict(
         type='TestTimeAug',
         transforms=[

--- a/configs/textrecog/aster/_base_aster.py
+++ b/configs/textrecog/aster/_base_aster.py
@@ -1,5 +1,3 @@
-file_client_args = dict(backend='disk')
-
 dictionary = dict(
     type='Dictionary',
     dict_file='{{ fileDirname }}/../../../dicts/english_digits_symbols.txt',
@@ -48,11 +46,7 @@ model = dict(
         std=[127.5, 127.5, 127.5]))
 
 train_pipeline = [
-    dict(
-        type='LoadImageFromFile',
-        file_client_args=file_client_args,
-        ignore_empty=True,
-        min_size=5),
+    dict(type='LoadImageFromFile', ignore_empty=True, min_size=5),
     dict(type='LoadOCRAnnotations', with_text=True),
     dict(type='Resize', scale=(256, 64)),
     dict(
@@ -61,7 +55,7 @@ train_pipeline = [
 ]
 
 test_pipeline = [
-    dict(type='LoadImageFromFile', file_client_args=file_client_args),
+    dict(type='LoadImageFromFile'),
     dict(type='Resize', scale=(256, 64)),
     dict(type='LoadOCRAnnotations', with_text=True),
     dict(
@@ -71,7 +65,7 @@ test_pipeline = [
 ]
 
 tta_pipeline = [
-    dict(type='LoadImageFromFile', file_client_args=file_client_args),
+    dict(type='LoadImageFromFile'),
     dict(
         type='TestTimeAug',
         transforms=[[

--- a/configs/textrecog/crnn/_base_crnn_mini-vgg.py
+++ b/configs/textrecog/crnn/_base_crnn_mini-vgg.py
@@ -18,12 +18,10 @@ model = dict(
     data_preprocessor=dict(
         type='TextRecogDataPreprocessor', mean=[127], std=[127]))
 
-file_client_args = dict(backend='disk')
 train_pipeline = [
     dict(
         type='LoadImageFromFile',
         color_type='grayscale',
-        file_client_args=file_client_args,
         ignore_empty=True,
         min_size=2),
     dict(type='LoadOCRAnnotations', with_text=True),
@@ -34,10 +32,7 @@ train_pipeline = [
 ]
 
 test_pipeline = [
-    dict(
-        type='LoadImageFromFile',
-        color_type='grayscale',
-        file_client_args=file_client_args),
+    dict(type='LoadImageFromFile', color_type='grayscale'),
     dict(
         type='RescaleToHeight',
         height=32,
@@ -53,10 +48,7 @@ test_pipeline = [
 ]
 
 tta_pipeline = [
-    dict(
-        type='LoadImageFromFile',
-        color_type='grayscale',
-        file_client_args=file_client_args),
+    dict(type='LoadImageFromFile', color_type='grayscale'),
     dict(
         type='TestTimeAug',
         transforms=[

--- a/configs/textrecog/master/_base_master_resnet31.py
+++ b/configs/textrecog/master/_base_master_resnet31.py
@@ -1,5 +1,3 @@
-file_client_args = dict(backend='disk')
-
 dictionary = dict(
     type='Dictionary',
     dict_file='{{ fileDirname }}/../../../dicts/english_digits_symbols.txt',
@@ -75,11 +73,7 @@ model = dict(
         std=[127.5, 127.5, 127.5]))
 
 train_pipeline = [
-    dict(
-        type='LoadImageFromFile',
-        file_client_args=file_client_args,
-        ignore_empty=True,
-        min_size=2),
+    dict(type='LoadImageFromFile', ignore_empty=True, min_size=2),
     dict(type='LoadOCRAnnotations', with_text=True),
     dict(
         type='RescaleToHeight',
@@ -94,7 +88,7 @@ train_pipeline = [
 ]
 
 test_pipeline = [
-    dict(type='LoadImageFromFile', file_client_args=file_client_args),
+    dict(type='LoadImageFromFile'),
     dict(
         type='RescaleToHeight',
         height=48,
@@ -111,7 +105,7 @@ test_pipeline = [
 ]
 
 tta_pipeline = [
-    dict(type='LoadImageFromFile', file_client_args=file_client_args),
+    dict(type='LoadImageFromFile'),
     dict(
         type='TestTimeAug',
         transforms=[

--- a/configs/textrecog/nrtr/_base_nrtr_modality-transform.py
+++ b/configs/textrecog/nrtr/_base_nrtr_modality-transform.py
@@ -1,5 +1,3 @@
-file_client_args = dict(backend='disk')
-
 dictionary = dict(
     type='Dictionary',
     dict_file='{{ fileDirname }}/../../../dicts/english_digits_symbols.txt',
@@ -26,11 +24,7 @@ model = dict(
         std=[58.395, 57.12, 57.375]))
 
 train_pipeline = [
-    dict(
-        type='LoadImageFromFile',
-        file_client_args=file_client_args,
-        ignore_empty=True,
-        min_size=2),
+    dict(type='LoadImageFromFile', ignore_empty=True, min_size=2),
     dict(type='LoadOCRAnnotations', with_text=True),
     dict(
         type='RescaleToHeight',
@@ -45,7 +39,7 @@ train_pipeline = [
 ]
 
 test_pipeline = [
-    dict(type='LoadImageFromFile', file_client_args=file_client_args),
+    dict(type='LoadImageFromFile'),
     dict(
         type='RescaleToHeight',
         height=32,
@@ -62,7 +56,7 @@ test_pipeline = [
 ]
 
 tta_pipeline = [
-    dict(type='LoadImageFromFile', file_client_args=file_client_args),
+    dict(type='LoadImageFromFile'),
     dict(
         type='TestTimeAug',
         transforms=[

--- a/configs/textrecog/nrtr/_base_nrtr_resnet31.py
+++ b/configs/textrecog/nrtr/_base_nrtr_resnet31.py
@@ -1,5 +1,3 @@
-file_client_args = dict(backend='disk')
-
 dictionary = dict(
     type='Dictionary',
     dict_file='{{ fileDirname }}/../../../dicts/english_digits_symbols.txt',
@@ -32,11 +30,7 @@ model = dict(
         std=[58.395, 57.12, 57.375]))
 
 train_pipeline = [
-    dict(
-        type='LoadImageFromFile',
-        file_client_args=file_client_args,
-        ignore_empty=True,
-        min_size=2),
+    dict(type='LoadImageFromFile', ignore_empty=True, min_size=2),
     dict(type='LoadOCRAnnotations', with_text=True),
     dict(
         type='RescaleToHeight',
@@ -51,7 +45,7 @@ train_pipeline = [
 ]
 
 test_pipeline = [
-    dict(type='LoadImageFromFile', file_client_args=file_client_args),
+    dict(type='LoadImageFromFile'),
     dict(
         type='RescaleToHeight',
         height=32,
@@ -68,7 +62,7 @@ test_pipeline = [
 ]
 
 tta_pipeline = [
-    dict(type='LoadImageFromFile', file_client_args=file_client_args),
+    dict(type='LoadImageFromFile'),
     dict(
         type='TestTimeAug',
         transforms=[

--- a/configs/textrecog/robust_scanner/_base_robustscanner_resnet31.py
+++ b/configs/textrecog/robust_scanner/_base_robustscanner_resnet31.py
@@ -29,14 +29,8 @@ model = dict(
         dictionary=dictionary,
         max_seq_len=30))
 
-file_client_args = dict(backend='disk')
-
 train_pipeline = [
-    dict(
-        type='LoadImageFromFile',
-        file_client_args=file_client_args,
-        ignore_empty=True,
-        min_size=2),
+    dict(type='LoadImageFromFile', ignore_empty=True, min_size=2),
     dict(type='LoadOCRAnnotations', with_text=True),
     dict(
         type='RescaleToHeight',
@@ -51,7 +45,7 @@ train_pipeline = [
 ]
 
 test_pipeline = [
-    dict(type='LoadImageFromFile', file_client_args=file_client_args),
+    dict(type='LoadImageFromFile'),
     dict(
         type='RescaleToHeight',
         height=48,
@@ -68,7 +62,7 @@ test_pipeline = [
 ]
 
 tta_pipeline = [
-    dict(type='LoadImageFromFile', file_client_args=file_client_args),
+    dict(type='LoadImageFromFile'),
     dict(
         type='TestTimeAug',
         transforms=[

--- a/configs/textrecog/sar/_base_sar_resnet31_parallel-decoder.py
+++ b/configs/textrecog/sar/_base_sar_resnet31_parallel-decoder.py
@@ -35,13 +35,8 @@ model = dict(
         dictionary=dictionary,
         max_seq_len=30))
 
-file_client_args = dict(backend='disk')
 train_pipeline = [
-    dict(
-        type='LoadImageFromFile',
-        file_client_args=file_client_args,
-        ignore_empty=True,
-        min_size=2),
+    dict(type='LoadImageFromFile', ignore_empty=True, min_size=2),
     dict(type='LoadOCRAnnotations', with_text=True),
     dict(
         type='RescaleToHeight',
@@ -56,7 +51,7 @@ train_pipeline = [
 ]
 
 test_pipeline = [
-    dict(type='LoadImageFromFile', file_client_args=file_client_args),
+    dict(type='LoadImageFromFile'),
     dict(
         type='RescaleToHeight',
         height=48,
@@ -73,7 +68,7 @@ test_pipeline = [
 ]
 
 tta_pipeline = [
-    dict(type='LoadImageFromFile', file_client_args=file_client_args),
+    dict(type='LoadImageFromFile'),
     dict(
         type='TestTimeAug',
         transforms=[

--- a/configs/textrecog/satrn/_base_satrn_shallow.py
+++ b/configs/textrecog/satrn/_base_satrn_shallow.py
@@ -1,5 +1,3 @@
-file_client_args = dict(backend='disk')
-
 dictionary = dict(
     type='Dictionary',
     dict_file='{{ fileDirname }}/../../../dicts/english_digits_symbols.txt',
@@ -42,11 +40,7 @@ model = dict(
         std=[58.395, 57.12, 57.375]))
 
 train_pipeline = [
-    dict(
-        type='LoadImageFromFile',
-        file_client_args=file_client_args,
-        ignore_empty=True,
-        min_size=2),
+    dict(type='LoadImageFromFile', ignore_empty=True, min_size=2),
     dict(type='LoadOCRAnnotations', with_text=True),
     dict(type='Resize', scale=(100, 32), keep_ratio=False),
     dict(
@@ -55,7 +49,7 @@ train_pipeline = [
 ]
 
 test_pipeline = [
-    dict(type='LoadImageFromFile', file_client_args=file_client_args),
+    dict(type='LoadImageFromFile'),
     dict(type='Resize', scale=(100, 32), keep_ratio=False),
     # add loading annotation after ``Resize`` because ground truth
     # does not need to do resize data transform
@@ -66,7 +60,7 @@ test_pipeline = [
 ]
 
 tta_pipeline = [
-    dict(type='LoadImageFromFile', file_client_args=file_client_args),
+    dict(type='LoadImageFromFile'),
     dict(
         type='TestTimeAug',
         transforms=[

--- a/configs/textrecog/svtr/_base_svtr-tiny.py
+++ b/configs/textrecog/svtr/_base_svtr-tiny.py
@@ -37,14 +37,8 @@ model = dict(
     data_preprocessor=dict(
         type='TextRecogDataPreprocessor', mean=[127.5], std=[127.5]))
 
-file_client_args = dict(backend='disk')
-
 train_pipeline = [
-    dict(
-        type='LoadImageFromFile',
-        file_client_args=file_client_args,
-        ignore_empty=True,
-        min_size=5),
+    dict(type='LoadImageFromFile', ignore_empty=True, min_size=5),
     dict(type='LoadOCRAnnotations', with_text=True),
     dict(
         type='RandomApply',
@@ -117,7 +111,7 @@ train_pipeline = [
 ]
 
 test_pipeline = [
-    dict(type='LoadImageFromFile', file_client_args=file_client_args),
+    dict(type='LoadImageFromFile'),
     dict(type='Resize', scale=(256, 64)),
     dict(type='LoadOCRAnnotations', with_text=True),
     dict(
@@ -126,7 +120,7 @@ test_pipeline = [
 ]
 
 tta_pipeline = [
-    dict(type='LoadImageFromFile', file_client_args=file_client_args),
+    dict(type='LoadImageFromFile'),
     dict(
         type='TestTimeAug',
         transforms=[[

--- a/docs/en/basic_concepts/transforms.md
+++ b/docs/en/basic_concepts/transforms.md
@@ -24,7 +24,6 @@ train_pipeline_r18 = [
     # Loading images
     dict(
         type='LoadImageFromFile',
-        file_client_args=file_client_args,
         color_type='color_ignore_orientation'),
     # Loading annotations
     dict(

--- a/docs/en/user_guides/config.md
+++ b/docs/en/user_guides/config.md
@@ -332,12 +332,10 @@ Due to the specificity of the OCR task, different models have different data aug
 
 ```Python
 # Data Augmentation
-file_client_args = dict(backend='disk')
 train_pipeline = [
     dict(
         type='LoadImageFromFile',
         color_type='grayscale',
-        file_client_args=dict(backend='disk'),
         ignore_empty=True,
         min_size=5),
     dict(type='LoadOCRAnnotations', with_text=True),
@@ -349,8 +347,7 @@ train_pipeline = [
 test_pipeline = [
     dict(
         type='LoadImageFromFile',
-        color_type='grayscale',
-        file_client_args=dict(backend='disk')),
+        color_type='grayscale'),
     dict(
         type='RescaleToHeight',
         height=32,

--- a/docs/zh_cn/basic_concepts/transforms.md
+++ b/docs/zh_cn/basic_concepts/transforms.md
@@ -24,7 +24,6 @@ train_pipeline_r18 = [
     # 数据读取（图像）
     dict(
         type='LoadImageFromFile',
-        file_client_args=file_client_args,
         color_type='color_ignore_orientation'),
     # 数据读取（标注）
     dict(

--- a/docs/zh_cn/user_guides/config.md
+++ b/docs/zh_cn/user_guides/config.md
@@ -329,12 +329,10 @@ MMOCR 中，数据集的构建与数据准备是相互解耦的。也就是说�
 
 ```Python
 # 数据增强
-file_client_args = dict(backend='disk')
 train_pipeline = [
     dict(
         type='LoadImageFromFile',
         color_type='grayscale',
-        file_client_args=dict(backend='disk'),
         ignore_empty=True,
         min_size=5),
     dict(type='LoadOCRAnnotations', with_text=True),
@@ -346,8 +344,7 @@ train_pipeline = [
 test_pipeline = [
     dict(
         type='LoadImageFromFile',
-        color_type='grayscale',
-        file_client_args=dict(backend='disk')),
+        color_type='grayscale'),
     dict(
         type='RescaleToHeight',
         height=32,

--- a/mmocr/datasets/recog_text_dataset.py
+++ b/mmocr/datasets/recog_text_dataset.py
@@ -7,8 +7,6 @@ from mmengine.fileio import list_from_file
 
 from mmocr.registry import DATASETS, TASK_UTILS
 
-# TODO: replace all list_from_file from mmengine
-
 
 @DATASETS.register_module()
 class RecogTextDataset(BaseDataset):
@@ -33,9 +31,8 @@ class RecogTextDataset(BaseDataset):
 
     Args:
         ann_file (str): Annotation file path. Defaults to ''.
-        file_client_args (dict, optional): Arguments to instantiate a
-            FileClient. See :class:`mmengine.fileio.FileClient` for details.
-            Default: None.
+        backend_args (dict, optional): Arguments to instantiate the
+            prefix of uri corresponding backend. Defaults to None.
         parse_cfg (dict, optional): Config of parser for parsing annotations.
             Use ``LineJsonParser`` when the annotation file is in jsonl format
             with keys of ``filename`` and ``text``. The keys in parse_cfg
@@ -75,7 +72,7 @@ class RecogTextDataset(BaseDataset):
 
     def __init__(self,
                  ann_file: str = '',
-                 file_client_args=None,
+                 backend_args=None,
                  parser_cfg: Optional[dict] = dict(
                      type='LineJsonParser', keys=['filename', 'text']),
                  metainfo: Optional[dict] = None,
@@ -90,7 +87,7 @@ class RecogTextDataset(BaseDataset):
                  max_refetch: int = 1000) -> None:
 
         self.parser = TASK_UTILS.build(parser_cfg)
-        self.file_client_args = file_client_args
+        self.backend_args = backend_args
         super().__init__(
             ann_file=ann_file,
             metainfo=metainfo,
@@ -112,7 +109,7 @@ class RecogTextDataset(BaseDataset):
         """
         data_list = []
         raw_anno_infos = list_from_file(
-            self.ann_file, file_client_args=self.file_client_args)
+            self.ann_file, backend_args=self.backend_args)
         for raw_anno_info in raw_anno_infos:
             data_list.append(self.parse_data_info(raw_anno_info))
         return data_list

--- a/mmocr/datasets/transforms/loading.py
+++ b/mmocr/datasets/transforms/loading.py
@@ -71,8 +71,9 @@ class LoadImageFromFile(MMCV_LoadImageFromFile):
         self.to_float32 = to_float32
         self.color_type = color_type
         self.imdecode_backend = imdecode_backend
-        # self.file_client = mmengine.FileClient(**self.file_client_args)
         self.min_size = min_size
+        self.file_client_args = file_client_args
+        self.backend_args = backend_args
         if file_client_args is not None:
             warnings.warn(
                 '"file_client_args" will be deprecated in future. '
@@ -98,7 +99,7 @@ class LoadImageFromFile(MMCV_LoadImageFromFile):
 
         filename = results['img_path']
         try:
-            if self.file_client_args is not None:
+            if getattr(self, 'file_client_args', None) is not None:
                 file_client = fileio.FileClient.infer_client(
                     self.file_client_args, filename)
                 img_bytes = file_client.get(filename)
@@ -405,7 +406,11 @@ class LoadOCRAnnotations(MMCV_LoadAnnotations):
         repr_str += f'with_polygon={self.with_polygon}, '
         repr_str += f'with_text={self.with_text}, '
         repr_str += f"imdecode_backend='{self.imdecode_backend}', "
-        repr_str += f'file_client_args={self.file_client_args})'
+
+        if self.file_client_args is not None:
+            repr_str += f'file_client_args={self.file_client_args})'
+        else:
+            repr_str += f'backend_args={self.backend_args})'
         return repr_str
 
 

--- a/mmocr/models/textrecog/recognizers/encoder_decoder_recognizer_tta.py
+++ b/mmocr/models/textrecog/recognizers/encoder_decoder_recognizer_tta.py
@@ -20,8 +20,7 @@ class EncoderDecoderRecognizerTTAModel(BaseTTAModel):
         >>> tta_pipeline = [
         >>>     dict(
         >>>         type='LoadImageFromFile',
-        >>>         color_type='grayscale',
-        >>>         file_client_args=file_client_args),
+        >>>         color_type='grayscale'),
         >>>     dict(
         >>>         type='TestTimeAug',
         >>>         transforms=[

--- a/projects/ABCNet/config/abcnet/_base_abcnet_resnet50_fpn.py
+++ b/projects/ABCNet/config/abcnet/_base_abcnet_resnet50_fpn.py
@@ -1,4 +1,3 @@
-file_client_args = dict(backend='disk')
 num_classes = 1
 strides = [8, 16, 32, 64, 128]
 bbox_coder = dict(type='mmdet.DistancePointBBoxCoder')
@@ -126,10 +125,7 @@ model = dict(
     ))
 
 test_pipeline = [
-    dict(
-        type='LoadImageFromFile',
-        file_client_args=file_client_args,
-        color_type='color_ignore_orientation'),
+    dict(type='LoadImageFromFile', color_type='color_ignore_orientation'),
     dict(type='Resize', scale=(2000, 4000), keep_ratio=True, backend='pillow'),
     dict(
         type='LoadOCRAnnotations',
@@ -143,10 +139,7 @@ test_pipeline = [
 ]
 
 train_pipeline = [
-    dict(
-        type='LoadImageFromFile',
-        file_client_args=file_client_args,
-        color_type='color_ignore_orientation'),
+    dict(type='LoadImageFromFile', color_type='color_ignore_orientation'),
     dict(
         type='LoadOCRAnnotations',
         with_polygon=True,

--- a/projects/ABCNet/config/abcnet_v2/_base_abcnet-v2_resnet50_bifpn.py
+++ b/projects/ABCNet/config/abcnet_v2/_base_abcnet-v2_resnet50_bifpn.py
@@ -1,4 +1,3 @@
-file_client_args = dict(backend='disk')
 num_classes = 1
 strides = [8, 16, 32, 64, 128]
 bbox_coder = dict(type='mmdet.DistancePointBBoxCoder')
@@ -105,10 +104,7 @@ model = dict(
     ))
 
 test_pipeline = [
-    dict(
-        type='LoadImageFromFile',
-        file_client_args=file_client_args,
-        color_type='color_ignore_orientation'),
+    dict(type='LoadImageFromFile', color_type='color_ignore_orientation'),
     dict(type='Resize', scale=(2000, 4000), keep_ratio=True, backend='pillow'),
     dict(
         type='LoadOCRAnnotations',

--- a/projects/SPTS/config/spts/_base_spts_resnet50.py
+++ b/projects/SPTS/config/spts/_base_spts_resnet50.py
@@ -1,8 +1,6 @@
 custom_imports = dict(
     imports=['projects.SPTS.spts'], allow_failed_imports=False)
 
-file_client_args = dict(backend='disk')
-
 dictionary = dict(
     type='SPTSDictionary',
     dict_file='{{ fileDirname }}/../../dicts/spts.txt',
@@ -53,10 +51,7 @@ model = dict(
         postprocessor=dict(type='SPTSPostprocessor', num_bins=num_bins)))
 
 test_pipeline = [
-    dict(
-        type='LoadImageFromFile',
-        file_client_args=file_client_args,
-        color_type='color_ignore_orientation'),
+    dict(type='LoadImageFromFile', color_type='color_ignore_orientation'),
     # dict(type='Resize', scale=(1000, 1824), keep_ratio=True),
     dict(
         type='RescaleToShortSide',
@@ -73,10 +68,7 @@ test_pipeline = [
 ]
 
 train_pipeline = [
-    dict(
-        type='LoadImageFromFile',
-        file_client_args=file_client_args,
-        color_type='color_ignore_orientation'),
+    dict(type='LoadImageFromFile', color_type='color_ignore_orientation'),
     dict(
         type='LoadOCRAnnotationsWithBezier',
         with_bbox=True,

--- a/projects/SPTS/spts/datasets/transforms/spts_transforms.py
+++ b/projects/SPTS/spts/datasets/transforms/spts_transforms.py
@@ -137,7 +137,12 @@ class LoadOCRAnnotationsWithBezier(LoadOCRAnnotations):
         repr_str += f'with_bezier={self.with_bezier}, '
         repr_str += f'with_text={self.with_text}, '
         repr_str += f"imdecode_backend='{self.imdecode_backend}', "
-        repr_str += f'file_client_args={self.file_client_args})'
+
+        if self.file_client_args is not None:
+            repr_str += f'file_client_args={self.file_client_args})'
+        else:
+            repr_str += f'backend_args={self.backend_args})'
+
         return repr_str
 
 

--- a/tests/test_datasets/test_transforms/test_loading.py
+++ b/tests/test_datasets/test_transforms/test_loading.py
@@ -29,7 +29,7 @@ class TestLoadImageFromFile(TestCase):
             repr(transform),
             ('LoadImageFromFile(ignore_empty=False, min_size=0, '
              "to_float32=False, color_type='color', imdecode_backend='cv2', "
-             "file_client_args={'backend': 'disk'})"))
+             'backend_args=None)'))
 
         # to_float32
         transform = LoadImageFromFile(to_float32=True)
@@ -130,7 +130,7 @@ class TestLoadOCRAnnotations(TestCase):
             repr(transform),
             ('LoadOCRAnnotations(with_bbox=True, with_label=True, '
              'with_polygon=True, with_text=True, '
-             "imdecode_backend='cv2', file_client_args=None)"))
+             "imdecode_backend='cv2', backend_args=None)"))
 
 
 class TestLoadKIEAnnotations(TestCase):

--- a/tools/analysis_tools/browse_dataset.py
+++ b/tools/analysis_tools/browse_dataset.py
@@ -259,7 +259,6 @@ def obtain_dataset_cfg(cfg: Config, phase: str, mode: str, task: str) -> Tuple:
             pipeline=[
                 dict(
                     type='LoadImageFromFile',
-                    file_client_args=dict(backend='disk'),
                     color_type='color_ignore_orientation'),
                 dict(
                     type='LoadOCRAnnotations',
@@ -277,11 +276,7 @@ def obtain_dataset_cfg(cfg: Config, phase: str, mode: str, task: str) -> Tuple:
                 name='visualizer',
                 vis_backends=[dict(type='LocalVisBackend')]),
             pipeline=[
-                dict(
-                    type='LoadImageFromFile',
-                    file_client_args=dict(backend='disk'),
-                    ignore_empty=True,
-                    min_size=2),
+                dict(type='LoadImageFromFile', ignore_empty=True, min_size=2),
                 dict(type='LoadOCRAnnotations', with_text=True),
                 dict(
                     type='PackTextRecogInputs',


### PR DESCRIPTION
Upgrade to use the new MMEngine interface. This upgrade requires `mmcv >= 2.0.0rc4`, which is already required by 1.0.0rc6.

## Motivation
Use the new interface of fileio from MMEngine which requires mmengine>=0.2.0.
Refer to https://github.com/open-mmlab/mmcv/pull/2468, https://github.com/open-mmlab/mmcv/pull/2539

mmcv<2.0.0rc4: need to set the file_client_args to indicate the backend, if the file_client_args is None, the default option will be disk backend.
mmcv>=2.0.0rc4 : The function in fileio from MMEngine will automatically deal with different backends according to the prefix of data_root, if parameter backend_args is None

## Reference
https://github.com/open-mmlab/mmselfsup/pull/662