### PR TITLE
Abinet: fix ValueError: Blur limit must be odd when centered=True. Got: (3, 6)

### DIFF
--- a/configs/textrecog/abinet/_base_abinet-vision.py
+++ b/configs/textrecog/abinet/_base_abinet-vision.py
@@ -80,7 +80,7 @@ train_pipeline = [
                 type='mmdet.Albu',
                 transforms=[
                     dict(type='GaussNoise', var_limit=(20, 20), p=0.5),
-                    dict(type='MotionBlur', blur_limit=6, p=0.5),
+                    dict(type='MotionBlur', blur_limit=7, p=0.5),
                 ]),
         ]),
     dict(


### PR DESCRIPTION
## Motivation

In response to #1794

## Modification

change blur_limit config of Albumentation MotionBlur form 6 to 7 to fix `ValueError: Blur limit must be odd when centered=True. Got: (3, 6)`

## Checklist

**Before PR**:

- [x] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmocr/blob/main/.github/CONTRIBUTING.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmocr/blob/main/.github/CONTRIBUTING.md) are used to fix the potential lint issues.
- [ ] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with some of those projects.
- [x] CLA has been signed and all committers have signed the CLA in this PR.
