### PR TITLE
[BUG] Bug generated during kie inference visualization

### DIFF
--- a/mmocr/visualization/kie_visualizer.py
+++ b/mmocr/visualization/kie_visualizer.py
@@ -70,8 +70,10 @@ class KIELocalVisualizer(BaseLocalVisualizer):
             np.ndarray: The image with edge labels drawn.
         """
         pairs = np.where(edge_labels > 0)
-        if torch.is_tensor(bboxes):
-          bboxes = bboxes.cpu()
+        
+        if torch.is_tensor(pairs):
+            pairs = pairs.cpu()
+            
         key_bboxes = bboxes[pairs[0]]
         value_bboxes = bboxes[pairs[1]]
         x_data = np.stack([(key_bboxes[:, 2] + key_bboxes[:, 0]) / 2,

--- a/mmocr/visualization/kie_visualizer.py
+++ b/mmocr/visualization/kie_visualizer.py
@@ -70,6 +70,8 @@ class KIELocalVisualizer(BaseLocalVisualizer):
             np.ndarray: The image with edge labels drawn.
         """
         pairs = np.where(edge_labels > 0)
+        if torch.is_tensor(bboxes):
+          bboxes = bboxes.cpu()
         key_bboxes = bboxes[pairs[0]]
         value_bboxes = bboxes[pairs[1]]
         x_data = np.stack([(key_bboxes[:, 2] + key_bboxes[:, 0]) / 2,


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

```shell
root@023ca4a78cff:/mmocr# CUDA_VISIBLE_DEVICES=2,3,4 python tools/infer.py demo/0000ae6cbdb1.png --det DBNet --rec CRNN --kie configs/kie/sdmgr/sdmgr_novisual_60e_wildreceipt-openset.py --kie-weights /home/making-graphs-accessible/input/epoch_2.pth --show --print-result
Loads checkpoint by http backend from path: https://download.openmmlab.com/mmocr/textdet/dbnet/dbnet_resnet50-oclip_1200e_icdar2015/dbnet_resnet50-oclip_1200e_icdar2015_20221102_115917-bde8c87a.pth
04/03 03:06:10 - mmengine - WARNING - "FileClient" will be deprecated in future. Please use io functions in https://mmengine.readthedocs.io/en/latest/api/fileio.html#file-io
04/03 03:06:10 - mmengine - WARNING - "HardDiskBackend" is the alias of "LocalBackend" and the former will be deprecated in future.
04/03 03:06:10 - mmengine - WARNING - Failed to search registry with scope "mmocr" in the "function" registry tree. As a workaround, the current "function" registry in "mmengine" is used to build instance. This may cause unexpected failure when running the built modules. Please check whether "mmocr" is a correct scope, or whether the registry is initialized.
04/03 03:06:10 - mmengine - WARNING - `Visualizer` backend is not initialized because save_dir is None.
Loads checkpoint by http backend from path: https://download.openmmlab.com/mmocr/textrecog/crnn/crnn_mini-vgg_5e_mj/crnn_mini-vgg_5e_mj_20220826_224120-8afbedbb.pth
The model and loaded state dict do not match exactly

unexpected key in source state_dict: data_preprocessor.mean, data_preprocessor.std

Loads checkpoint by local backend from path: /home/making-graphs-accessible/input/epoch_2.pth
Loads checkpoint by local backend from path: /home/making-graphs-accessible/input/epoch_2.pth
/opt/conda/lib/python3.7/site-packages/torch/nn/functional.py:718: UserWarning: Named tensors and all their associated APIs are an experimental feature and subject to change. Please do not use them for anything important until they are released as stable. (Triggered
internally at  /opt/conda/conda-bld/pytorch_1623448265233/work/c10/core/TensorImpl.h:1156.)
  return torch.max_pool2d(input, kernel_size, stride, padding, dilation, ceil_mode)
Inference ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
Traceback (most recent call last):
  File "tools/infer.py", line 100, in <module>
    main()
  File "tools/infer.py", line 96, in main
    ocr(**call_args)
  File "/mmocr/mmocr/apis/inferencers/mmocr_inferencer.py", line 279, in __call__
    ori_input, preds, img_out_dir=img_out_dir, **visualize_kwargs)
  File "/mmocr/mmocr/apis/inferencers/mmocr_inferencer.py", line 205, in visualize
    **kwargs)
  File "/mmocr/mmocr/apis/inferencers/kie_inferencer.py", line 262, in visualize
    out_file=out_file,
  File "/mmocr/mmocr/visualization/kie_visualizer.py", line 259, in add_datasample
    self.is_openset, 'r')
  File "/mmocr/mmocr/visualization/kie_visualizer.py", line 191, in _draw_instances
    texts, arrow_colors)
  File "/mmocr/mmocr/visualization/kie_visualizer.py", line 77, in _draw_edge_label
    axis=-1)
  File "<__array_function__ internals>", line 6, in stack
  File "/opt/conda/lib/python3.7/site-packages/numpy/core/shape_base.py", line 421, in stack
    arrays = [asanyarray(arr) for arr in arrays]
  File "/opt/conda/lib/python3.7/site-packages/numpy/core/shape_base.py", line 421, in <listcomp>
    arrays = [asanyarray(arr) for arr in arrays]
  File "/opt/conda/lib/python3.7/site-packages/numpy/core/_asarray.py", line 171, in asanyarray
    return array(a, dtype, copy=False, order=order, subok=True)
  File "/opt/conda/lib/python3.7/site-packages/torch/_tensor.py", line 643, in __array__
    return self.numpy()
TypeError: can't convert cuda:0 device type tensor to numpy. Use Tensor.cpu() to copy the tensor to host memory first.
root@023ca4a78cff:/mmocr# vim /mmocr/mmocr/visualization/kie_visualizer.py
root@023ca4a78cff:/mmocr#
```

## Modification

When using GPU for KIE visualization, there will be BUG.
```python
class KIELocalVisualizer(BaseLocalVisualizer):
    """The MMOCR Text Detection Local Visualizer.
    Args:
        name (str): Name of the instance. Defaults to 'visualizer'.
        image (np.ndarray, optional): the origin image to draw. The format
            should be RGB. Defaults to None.
        vis_backends (list, optional): Visual backend config list.
            Default to None.
        save_dir (str, optional): Save file dir for all storage backends.
            If it is None, the backend storage will not save any data.
        fig_save_cfg (dict): Keyword parameters of figure for saving.
            Defaults to empty dict.
        fig_show_cfg (dict): Keyword parameters of figure for showing.
            Defaults to empty dict.
        is_openset (bool, optional): Whether the visualizer is used in
            OpenSet. Defaults to False.
    """

    def __init__(self,
                 name: str = 'kie_visualizer',
                 is_openset: bool = False,
                 **kwargs) -> None:
        super().__init__(name=name, **kwargs)
        self.is_openset = is_openset

    def _draw_edge_label(self,
                         image: np.ndarray,
                         edge_labels: Union[np.ndarray, torch.Tensor],
                         bboxes: Union[np.ndarray, torch.Tensor],
                         texts: Sequence[str],
                         arrow_colors: str = 'g') -> np.ndarray:
        """Draw edge labels on image.
        Args:
            image (np.ndarray): The origin image to draw. The format
                should be RGB.
            edge_labels (np.ndarray or torch.Tensor): The edge labels to draw.
                The shape of edge_labels should be (N, N), where N is the
                number of texts.
            bboxes (np.ndarray or torch.Tensor): The bboxes to draw. The shape
                of bboxes should be (N, 4), where N is the number of texts.
            texts (Sequence[str]): The texts to draw. The length of texts
                should be the same as the number of bboxes.
            arrow_colors (str, optional): The colors of arrows. Refer to
                `matplotlib.colors` for full list of formats that are accepted.
                Defaults to 'g'.
        Returns:
            np.ndarray: The image with edge labels drawn.
        """
        pairs = np.where(edge_labels > 0)
        key_bboxes = bboxes[pairs[0]]
        value_bboxes = bboxes[pairs[1]]
        x_data = np.stack([(key_bboxes[:, 2] + key_bboxes[:, 0]) / 2,
                           (value_bboxes[:, 0] + value_bboxes[:, 2]) / 2],
                          axis=-1)
        y_data = np.stack([(key_bboxes[:, 1] + key_bboxes[:, 3]) / 2,
                           (value_bboxes[:, 1] + value_bboxes[:, 3]) / 2],
                          axis=-1)
        key_index = np.array(list(set(pairs[0])))
        val_index = np.array(list(set(pairs[1])))
        key_texts = [texts[i] for i in key_index]
        val_texts = [texts[i] for i in val_index]

        self.set_image(image)
        if key_texts:
            self.draw_texts(
                key_texts, (bboxes[key_index, :2] + bboxes[key_index, 2:]) / 2,
                colors='k',
                horizontal_alignments='center',
                vertical_alignments='center',
                font_families=self.font_families,
                font_properties=self.font_properties)
        if val_texts:
            self.draw_texts(
                val_texts, (bboxes[val_index, :2] + bboxes[val_index, 2:]) / 2,
                colors='k',
                horizontal_alignments='center',
                vertical_alignments='center',
                font_families=self.font_families,
                font_properties=self.font_properties)
        self.draw_arrows(
            x_data,
            y_data,
            colors=arrow_colors,
            line_widths=0.3,
            arrow_tail_widths=0.05,
            arrow_head_widths=5,
            overhangs=1,
            arrow_shapes='full')
        return self.get_image()
```

Added the following two lines for type conversion

```python
if torch.is_tensor(pairs):
  pairs = pairs.cpu()
```

## Checklist

**Before PR**:

- [x] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmocr/blob/main/.github/CONTRIBUTING.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmocr/blob/main/.github/CONTRIBUTING.md) are used to fix the potential lint issues.
- [x] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [x] If the modification has potential influence on downstream or other related projects, this PR should be tested with some of those projects.
- [x] CLA has been signed and all committers have signed the CLA in this PR.
