### PR TITLE
[Fix] fix a rec inference vis bug

### DIFF
--- a/mmocr/apis/inferencers/mmocr_inferencer.py
+++ b/mmocr/apis/inferencers/mmocr_inferencer.py
@@ -232,7 +232,8 @@ class MMOCRInferencer(BaseMMOCRInferencer):
                                          **kwargs)
             else:
                 return self.textrec_inferencer.visualize(
-                    self.rec_inputs, preds['rec'][0], **kwargs)
+                    self.rec_inputs, [pred[0] for pred in preds['rec']],
+                    **kwargs)
         else:
             return self.textdet_inferencer.visualize(inputs, preds['det'],
                                                      **kwargs)

--- a/tests/test_apis/test_inferencers/test_mmocr_inferencer.py
+++ b/tests/test_apis/test_inferencers/test_mmocr_inferencer.py
@@ -150,6 +150,13 @@ class TestMMOCRInferencer(TestCase):
                     osp.join(tmp_dir, 'preds', pred_dir))
                 self.assert_predictions_equal(res['predictions'][i],
                                               dumped_res)
+            # test different batch sizes
+            img_dir = 'tests/data/rec_toy_dataset/imgs'
+            res_bs3 = inferencer(img_dir, batch_size=3, return_vis=True)
+            self.assertIn('visualization', res_bs3)
+            self.assertIn('predictions', res_bs3)
+            self.assertEqual(
+                len(res_bs3['predictions']), len(res_bs3['visualization']))
 
     @mock.patch('mmengine.infer.infer._load_checkpoint')
     def test_det_rec(self, mock_load):


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

visualization only has the first data when rec_batch_size>1.

## Modification

flatten preds['rec] and update unit test

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

**Before PR**:

- [ ] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmocr/blob/main/.github/CONTRIBUTING.md) to create this PR.
- [ ] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmocr/blob/main/.github/CONTRIBUTING.md) are used to fix the potential lint issues.
- [ ] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with some of those projects.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
