### PR TITLE
[Fix] fix multithreading concurrency visualization error.

### DIFF
--- a/mmocr/apis/inferencers/kie_inferencer.py
+++ b/mmocr/apis/inferencers/kie_inferencer.py
@@ -1,7 +1,6 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 import copy
-import os.path as osp
-from typing import Any, Dict, List, Optional, Sequence, Union
+from typing import Any, Dict, Optional, Sequence, Union
 
 import mmcv
 import mmengine
@@ -12,7 +11,7 @@ from mmengine.runner.checkpoint import _load_checkpoint
 from mmocr.registry import DATASETS
 from mmocr.structures import KIEDataSample
 from mmocr.utils import ConfigType
-from .base_mmocr_inferencer import BaseMMOCRInferencer, ModelType, PredType
+from .base_mmocr_inferencer import BaseMMOCRInferencer, ModelType
 
 InputType = Dict
 InputsType = Sequence[Dict]
@@ -185,85 +184,6 @@ class KIEInferencer(BaseMMOCRInferencer):
                     raise ValueError(f'Unsupported input type: {atype}')
 
         return processed_inputs
-
-    def visualize(self,
-                  inputs: InputsType,
-                  preds: PredType,
-                  return_vis: bool = False,
-                  show: bool = False,
-                  wait_time: int = 0,
-                  draw_pred: bool = True,
-                  pred_score_thr: float = 0.3,
-                  save_vis: bool = False,
-                  img_out_dir: str = '') -> Union[List[np.ndarray], None]:
-        """Visualize predictions.
-
-        Args:
-            inputs (List[Union[str, np.ndarray]]): Inputs for the inferencer.
-            preds (List[Dict]): Predictions of the model.
-            return_vis (bool): Whether to return the visualization result.
-                Defaults to False.
-            show (bool): Whether to display the image in a popup window.
-                Defaults to False.
-            wait_time (float): The interval of show (s). Defaults to 0.
-            draw_pred (bool): Whether to draw predicted bounding boxes.
-                Defaults to True.
-            pred_score_thr (float): Minimum score of bboxes to draw.
-                Defaults to 0.3.
-            save_vis (bool): Whether to save the visualization result. Defaults
-                to False.
-            img_out_dir (str): Output directory of visualization results.
-                If left as empty, no file will be saved. Defaults to ''.
-
-        Returns:
-            List[np.ndarray] or None: Returns visualization results only if
-            applicable.
-        """
-        if self.visualizer is None or not (show or save_vis or return_vis):
-            return None
-
-        if getattr(self, 'visualizer') is None:
-            raise ValueError('Visualization needs the "visualizer" term'
-                             'defined in the config, but got None.')
-
-        results = []
-
-        for single_input, pred in zip(inputs, preds):
-            assert 'img' in single_input or 'img_shape' in single_input
-            if 'img' in single_input:
-                if isinstance(single_input['img'], str):
-                    img_bytes = mmengine.fileio.get(single_input['img'])
-                    img = mmcv.imfrombytes(img_bytes, channel_order='rgb')
-                elif isinstance(single_input['img'], np.ndarray):
-                    img = single_input['img'].copy()[:, :, ::-1]  # To RGB
-            elif 'img_shape' in single_input:
-                img = np.zeros(single_input['img_shape'], dtype=np.uint8)
-            else:
-                raise ValueError('Input does not contain either "img" or '
-                                 '"img_shape"')
-            img_name = osp.splitext(osp.basename(pred.img_path))[0]
-
-            if save_vis and img_out_dir:
-                out_file = osp.splitext(img_name)[0]
-                out_file = f'{out_file}.jpg'
-                out_file = osp.join(img_out_dir, out_file)
-            else:
-                out_file = None
-
-            visualization = self.visualizer.add_datasample(
-                img_name,
-                img,
-                pred,
-                show=show,
-                wait_time=wait_time,
-                draw_gt=False,
-                draw_pred=draw_pred,
-                pred_score_thr=pred_score_thr,
-                out_file=out_file,
-            )
-            results.append(visualization)
-
-        return results
 
     def pred2dict(self, data_sample: KIEDataSample) -> Dict:
         """Extract elements necessary to represent a prediction into a

--- a/mmocr/visualization/kie_visualizer.py
+++ b/mmocr/visualization/kie_visualizer.py
@@ -7,6 +7,7 @@ import numpy as np
 import torch
 from matplotlib.collections import PatchCollection
 from matplotlib.patches import FancyArrow
+from mmengine.utils.manager import _accquire_lock, _release_lock
 from mmengine.visualization import Visualizer
 from mmengine.visualization.utils import (check_type, check_type_and_length,
                                           color_val_matplotlib, tensor2ndarray,
@@ -233,6 +234,7 @@ class KIELocalVisualizer(BaseLocalVisualizer):
             out_file (str): Path to output file. Defaults to None.
             step (int): Global step value to record. Defaults to 0.
         """
+        _accquire_lock()
         cat_images = list()
 
         if draw_gt:
@@ -274,7 +276,10 @@ class KIELocalVisualizer(BaseLocalVisualizer):
             mmcv.imwrite(cat_images[..., ::-1], out_file)
 
         self.set_image(cat_images)
-        return self.get_image()
+        drawn_rgb_image = self.get_image()
+        _release_lock()
+
+        return drawn_rgb_image
 
     def draw_arrows(self,
                     x_data: Union[np.ndarray, torch.Tensor],

--- a/mmocr/visualization/textdet_visualizer.py
+++ b/mmocr/visualization/textdet_visualizer.py
@@ -4,6 +4,7 @@ from typing import Dict, List, Optional, Sequence, Tuple, Union
 import mmcv
 import numpy as np
 import torch
+from mmengine.utils.manager import _accquire_lock, _release_lock
 
 from mmocr.registry import VISUALIZERS
 from mmocr.structures import TextDetDataSample
@@ -147,6 +148,7 @@ class TextDetLocalVisualizer(BaseLocalVisualizer):
                 and masks. Defaults to 0.3.
             step (int): Global step value to record. Defaults to 0.
         """
+        _accquire_lock()
         cat_images = []
         if data_sample is not None:
             if draw_gt and 'gt_instances' in data_sample:
@@ -191,4 +193,7 @@ class TextDetLocalVisualizer(BaseLocalVisualizer):
             mmcv.imwrite(cat_images[..., ::-1], out_file)
 
         self.set_image(cat_images)
-        return self.get_image()
+        drawn_rgb_image = self.get_image()
+        _release_lock()
+
+        return drawn_rgb_image

--- a/mmocr/visualization/textrecog_visualizer.py
+++ b/mmocr/visualization/textrecog_visualizer.py
@@ -4,6 +4,7 @@ from typing import Dict, Optional, Tuple, Union
 import cv2
 import mmcv
 import numpy as np
+from mmengine.utils.manager import _accquire_lock, _release_lock
 
 from mmocr.registry import VISUALIZERS
 from mmocr.structures import TextRecogDataSample
@@ -112,6 +113,7 @@ class TextRecogLocalVisualizer(BaseLocalVisualizer):
             pred_score_thr (float): Threshold of prediction score. It's not
                 used in this function. Defaults to None.
         """
+        _accquire_lock()
         height, width = image.shape[:2]
         resize_height = 64
         resize_width = int(1.0 * width / height * resize_height)
@@ -141,4 +143,7 @@ class TextRecogLocalVisualizer(BaseLocalVisualizer):
             mmcv.imwrite(cat_images[..., ::-1], out_file)
 
         self.set_image(cat_images)
-        return self.get_image()
+        drawn_rgb_image = self.get_image()
+        _release_lock()
+
+        return drawn_rgb_image

--- a/mmocr/visualization/textspotting_visualizer.py
+++ b/mmocr/visualization/textspotting_visualizer.py
@@ -4,6 +4,7 @@ from typing import Optional, Sequence, Union
 import mmcv
 import numpy as np
 import torch
+from mmengine.utils.manager import _accquire_lock, _release_lock
 
 from mmocr.registry import VISUALIZERS
 from mmocr.structures import TextDetDataSample
@@ -103,6 +104,7 @@ class TextSpottingLocalVisualizer(BaseLocalVisualizer):
                 and masks. Defaults to 0.3.
             step (int): Global step value to record. Defaults to 0.
         """
+        _accquire_lock()
         cat_images = []
 
         if data_sample is not None:
@@ -141,4 +143,7 @@ class TextSpottingLocalVisualizer(BaseLocalVisualizer):
             mmcv.imwrite(cat_images[..., ::-1], out_file)
 
         self.set_image(cat_images)
-        return self.get_image()
+        drawn_rgb_image = self.get_image()
+        _release_lock()
+
+        return drawn_rgb_image


### PR DESCRIPTION

Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

mmocr_inferencer visualization results error when using multithreading concurrency.

## Modification

1.add threading lock for all visualizer.
2.replace self.rec_inputs and self.kie_inputs with rec_inputs and kie_inputs
3.delete kie_inferencer's visualize function, just use BaseMMOCRInferencer's visualize function like det/rec

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

**Before PR**:

- [ ] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmocr/blob/main/.github/CONTRIBUTING.md) to create this PR.
- [ ] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmocr/blob/main/.github/CONTRIBUTING.md) are used to fix the potential lint issues.
- [ ] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with some of those projects.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
