### PR TITLE
[Fix] fix an error when using get_flops.py script to get textrecog model flops.

### DIFF
--- a/tools/analysis_tools/get_flops.py
+++ b/tools/analysis_tools/get_flops.py
@@ -38,6 +38,7 @@ def main():
     cfg = Config.fromfile(args.config)
     init_default_scope(cfg.get('default_scope', 'mmocr'))
     model = MODELS.build(cfg.model)
+    model.eval()
 
     flops = FlopCountAnalysis(model, torch.ones(input_shape))
 


### PR DESCRIPTION


Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

```
(base) mmocr fix_textrecog_get_flops_error ✗ 4m △ ◒ ➜  /usr/bin/env /Users/wangnu/opt/anaconda3/envs/openmmlab2.0/bin/python /Users/wangnu/.vscode/
extensions/ms-python.python-2023.12.0/pythonFiles/lib/python/debugpy/adapter/../../debugpy/launcher 63593 -- /Users/wangnu/Documents/GitHub/mmocr/t
ools/analysis_tools/get_flops.py /Users/wangnu/Documents/GitHub/mmocr/configs/textrecog/abinet/abinet_20e_st-an_mj.py --shape 32 128 
conda activate openmmlab2.0
/Users/wangnu/Documents/GitHub/mmocr/mmocr/models/textrecog/module_losses/ce_module_loss.py:101: UserWarning: padding does not exist in the dictionary
  warnings.warn(
/Users/wangnu/Documents/GitHub/mmocr/mmocr/models/textrecog/postprocessors/base.py:60: UserWarning: padding does not exist in the dictionary
  warnings.warn(
Traceback (most recent call last):
  File "/Users/wangnu/opt/anaconda3/envs/openmmlab2.0/lib/python3.8/runpy.py", line 194, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/Users/wangnu/opt/anaconda3/envs/openmmlab2.0/lib/python3.8/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/Users/wangnu/.vscode/extensions/ms-python.python-2023.12.0/pythonFiles/lib/python/debugpy/adapter/../../debugpy/launcher/../../debugpy/__main__.py", line 39, in <module>
    cli.main()
  File "/Users/wangnu/.vscode/extensions/ms-python.python-2023.12.0/pythonFiles/lib/python/debugpy/adapter/../../debugpy/launcher/../../debugpy/../debugpy/server/cli.py", line 430, in main
    run()
  File "/Users/wangnu/.vscode/extensions/ms-python.python-2023.12.0/pythonFiles/lib/python/debugpy/adapter/../../debugpy/launcher/../../debugpy/../debugpy/server/cli.py", line 284, in run_file
    runpy.run_path(target, run_name="__main__")
  File "/Users/wangnu/.vscode/extensions/ms-python.python-2023.12.0/pythonFiles/lib/python/debugpy/_vendored/pydevd/_pydevd_bundle/pydevd_runpy.py", line 321, in run_path
    return _run_module_code(code, init_globals, run_name,
  File "/Users/wangnu/.vscode/extensions/ms-python.python-2023.12.0/pythonFiles/lib/python/debugpy/_vendored/pydevd/_pydevd_bundle/pydevd_runpy.py", line 135, in _run_module_code
    _run_code(code, mod_globals, init_globals,
  File "/Users/wangnu/.vscode/extensions/ms-python.python-2023.12.0/pythonFiles/lib/python/debugpy/_vendored/pydevd/_pydevd_bundle/pydevd_runpy.py", line 124, in _run_code
    exec(code, run_globals)
  File "/Users/wangnu/Documents/GitHub/mmocr/tools/analysis_tools/get_flops.py", line 56, in <module>
    main()
  File "/Users/wangnu/Documents/GitHub/mmocr/tools/analysis_tools/get_flops.py", line 46, in main
    flops_data = flop_count_table(flops)
  File "/Users/wangnu/opt/anaconda3/envs/openmmlab2.0/lib/python3.8/site-packages/fvcore/nn/print_model_statistics.py", line 632, in flop_count_table
    stats = {params_header: params, flops_header: flops.by_module()}
  File "/Users/wangnu/opt/anaconda3/envs/openmmlab2.0/lib/python3.8/site-packages/fvcore/nn/jit_analysis.py", line 291, in by_module
    stats = self._analyze()
  File "/Users/wangnu/opt/anaconda3/envs/openmmlab2.0/lib/python3.8/site-packages/fvcore/nn/jit_analysis.py", line 551, in _analyze
    graph = _get_scoped_trace_graph(self._model, self._inputs, self._aliases)
  File "/Users/wangnu/opt/anaconda3/envs/openmmlab2.0/lib/python3.8/site-packages/fvcore/nn/jit_analysis.py", line 176, in _get_scoped_trace_graph
    graph, _ = _get_trace_graph(module, inputs)
  File "/Users/wangnu/opt/anaconda3/envs/openmmlab2.0/lib/python3.8/site-packages/torch/jit/_trace.py", line 1184, in _get_trace_graph
    outs = ONNXTracedModule(f, strict, _force_outplace, return_inputs, _return_inputs_states)(*args, **kwargs)
  File "/Users/wangnu/opt/anaconda3/envs/openmmlab2.0/lib/python3.8/site-packages/torch/nn/modules/module.py", line 1194, in _call_impl
    return forward_call(*input, **kwargs)
  File "/Users/wangnu/opt/anaconda3/envs/openmmlab2.0/lib/python3.8/site-packages/torch/jit/_trace.py", line 127, in forward
    graph, out = torch._C._create_graph_by_tracing(
  File "/Users/wangnu/opt/anaconda3/envs/openmmlab2.0/lib/python3.8/site-packages/torch/jit/_trace.py", line 118, in wrapper
    outs.append(self.inner(*trace_inputs))
  File "/Users/wangnu/opt/anaconda3/envs/openmmlab2.0/lib/python3.8/site-packages/torch/nn/modules/module.py", line 1212, in _call_impl
    result = forward_call(*input, **kwargs)
  File "/Users/wangnu/opt/anaconda3/envs/openmmlab2.0/lib/python3.8/site-packages/torch/nn/modules/module.py", line 1182, in _slow_forward
    result = self.forward(*input, **kwargs)
  File "/Users/wangnu/Documents/GitHub/mmocr/mmocr/models/textrecog/recognizers/base.py", line 92, in forward
    return self._forward(inputs, data_samples, **kwargs)
  File "/Users/wangnu/Documents/GitHub/mmocr/mmocr/models/textrecog/recognizers/encoder_decoder_recognizer.py", line 130, in _forward
    return self.decoder(feat, out_enc, data_samples)
  File "/Users/wangnu/opt/anaconda3/envs/openmmlab2.0/lib/python3.8/site-packages/torch/nn/modules/module.py", line 1212, in _call_impl
    result = forward_call(*input, **kwargs)
  File "/Users/wangnu/opt/anaconda3/envs/openmmlab2.0/lib/python3.8/site-packages/torch/nn/modules/module.py", line 1182, in _slow_forward
    result = self.forward(*input, **kwargs)
  File "/Users/wangnu/Documents/GitHub/mmocr/mmocr/models/textrecog/decoders/base.py", line 163, in forward
    data_samples = self.module_loss.get_targets(data_samples)
  File "/Users/wangnu/Documents/GitHub/mmocr/mmocr/models/textrecog/module_losses/base.py", line 98, in get_targets
    for data_sample in data_samples:
TypeError: 'NoneType' object is not iterable
```

## Modification

https://github.com/open-mmlab/mmocr/blob/1dcd6fa6958de22bcb997319833f0ac19c180ec7/mmocr/models/textrecog/decoders/base.py#L161-L166

different from textdet model, self.training is used here instead of self.mode

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

**Before PR**:

- [ ] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmocr/blob/main/.github/CONTRIBUTING.md) to create this PR.
- [ ] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmocr/blob/main/.github/CONTRIBUTING.md) are used to fix the potential lint issues.
- [ ] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with some of those projects.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
