### PR TITLE
Fix double split-text issue causing incorrect filename truncation

### DIFF
--- a/mmocr/apis/inferencers/base_mmocr_inferencer.py
+++ b/mmocr/apis/inferencers/base_mmocr_inferencer.py
@@ -295,7 +295,7 @@ class BaseMMOCRInferencer(BaseInferencer):
             img_name = osp.splitext(osp.basename(pred.img_path))[0]
 
             if save_vis and img_out_dir:
-                out_file = osp.splitext(img_name)[0]
+                out_file = img_name
                 out_file = f'{out_file}.jpg'
                 out_file = osp.join(img_out_dir, out_file)
             else:


### PR DESCRIPTION
Resolved an issue where using split-text twice resulted in incorrect truncation of filenames containing multiple dots. For instance, a file named '2018_01_Items_1-2-2018-2191.30.jpg' was being improperly shortened to '2018_01_Items_1-2-2018-2191.jpg'.

Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Please describe the motivation of this PR and the goal you want to achieve through this PR.

## Modification

Please briefly describe what modification is made in this PR.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

**Before PR**:

- [ ] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmocr/blob/main/.github/CONTRIBUTING.md) to create this PR.
- [ ] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmocr/blob/main/.github/CONTRIBUTING.md) are used to fix the potential lint issues.
- [ ] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with some of those projects.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
