### PR TITLE
Fix the logic of min text area in PostProcess of PseNet

### DIFF
--- a/mmocr/models/textdet/postprocessors/pse_postprocessor.py
+++ b/mmocr/models/textdet/postprocessors/pse_postprocessor.py
@@ -93,7 +93,7 @@ class PSEPostprocessor(PANPostprocessor):
             area = points.shape[0]
             score_instance = np.mean(score[labels == i])
             if not (area >= self.min_text_area
-                    or score_instance > self.score_threshold):
+                    and score_instance > self.score_threshold):
                 continue
 
             polygon = self._points2boundary(points)


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation
Fix the bug only :>

Please describe the motivation of this PR and the goal you want to achieve through this PR.

## Modification
Correct the logic of min text area. The old version of code will let the model of PseNet predict really small text box region.
I just change the operator "or" to "and" for the correctness of the logic. 

Please briefly describe what modification is made in this PR.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

**Before PR**:

- [x] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmocr/blob/main/.github/CONTRIBUTING.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmocr/blob/main/.github/CONTRIBUTING.md) are used to fix the potential lint issues.
- [x] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [x] If the modification has potential influence on downstream or other related projects, this PR should be tested with some of those projects.
- [x] CLA has been signed and all committers have signed the CLA in this PR.
