### PR TITLE
[Fix] fix a bug in e2e_hmean_iou_metric.py for in-place filtering bug

### DIFF
--- a/projects/ABCNet/abcnet/metric/e2e_hmean_iou_metric.py
+++ b/projects/ABCNet/abcnet/metric/e2e_hmean_iou_metric.py
@@ -168,7 +168,7 @@ class E2EHmeanIOUMetric(BaseMetric):
             for i, pred_score_thr in enumerate(self.pred_score_thrs):
                 pred_ignore_flags = pred_scores < pred_score_thr
                 # get the number of matched boxes
-                pred_texts = [
+                filtered_pred_texts = [
                     pred_texts[j]
                     for j in self._true_indexes(~pred_ignore_flags)
                 ]
@@ -192,11 +192,11 @@ class E2EHmeanIOUMetric(BaseMetric):
                         matched_gt_indexes.add(gt_idx)
                         matched_pred_indexes.add(pred_idx)
                         if self.word_spotting:
-                            if gt_texts[gt_idx] == pred_texts[pred_idx]:
+                            if gt_texts[gt_idx] == filtered_pred_texts[pred_idx]:
                                 matched_e2e_gt_indexes.add(gt_idx)
                         else:
                             if self.text_match(gt_texts[gt_idx].upper(),
-                                               pred_texts[pred_idx].upper()):
+                                               filtered_pred_texts[pred_idx].upper()):
                                 matched_e2e_gt_indexes.add(gt_idx)
                     dataset_hit_num[i] += len(matched_e2e_gt_indexes)
                 dataset_pred_num[i] += np.sum(~pred_ignore_flags)


### PR DESCRIPTION
## Motivation

This PR aims to fix a bug in the ABCNet project. The bug occurs when performing in-place filtering on predicted texts, causing subsequent filtering operations to fail.

## Modification

The bug is fixed by creating a new list `filtered_pred_texts` to store the filtered prediction texts, ensuring that the original `pred_texts` list is not modified in-place.

## BC-breaking (Optional)

N/A

## Use cases (Optional)

N/A

## Checklist

**Before PR**:

- [ ] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmocr/blob/main/.github/CONTRIBUTING.md) to create this PR.
- [ ] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmocr/blob/main/.github/CONTRIBUTING.md) are used to fix the potential lint issues.
- [ ] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with some of those projects.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
