### PR TITLE
Update __init__.py to inclusively handle maximum version

### DIFF
--- a/mmocr/__init__.py
+++ b/mmocr/__init__.py
@@ -47,7 +47,7 @@ mmdet_maximum_version = '3.2.0'
 mmdet_version = digit_version(mmdet.__version__)
 
 assert (mmdet_version >= digit_version(mmdet_minimum_version)
-        and mmdet_version < digit_version(mmdet_maximum_version)), \
+        and mmdet_version <= digit_version(mmdet_maximum_version)), \
     f'MMDetection {mmdet.__version__} is incompatible ' \
     f'with MMOCR {__version__}. ' \
     f'Please use MMDetection >= {mmdet_minimum_version}, ' \


### PR DESCRIPTION
Updated to accept up to version 3.2.0 (the current latest version), instead of accepting only versions less than 3.2.0.

## Motivation

Issue #2000, unable to install mmocr using the standard instructions on a fresh environment led me to experience this compatibility issue.

## Modification

Changed compatibility in mmocr __init__.py file to be inclusive of the maximum version (3.2.0), instead of including strictly less than the maximum version.