### PR TITLE
When testing my model with tools/test.py, my config will be messed up by the "--save-preds" option. 

### DIFF
--- a/tools/test.py
+++ b/tools/test.py
@@ -121,6 +121,11 @@ def main():
         if isinstance(cfg.test_evaluator, (list, tuple)):
             cfg.test_evaluator = list(cfg.test_evaluator)
             cfg.test_evaluator.append(dump_metric)
+        if isinstance(cfg.test_evaluator, dict):
+            if 'metrics' in cfg.test_evaluator.keys():
+                cfg.test_evaluator['metrics'].append(dump_metric)
+            else:
+                cfg.test_evaluator['metrics'] = [dump_metric]
         else:
             cfg.test_evaluator = [cfg.test_evaluator, dump_metric]
 

--- a/tools/test.py
+++ b/tools/test.py
@@ -122,7 +122,7 @@ def main():
             cfg.test_evaluator = list(cfg.test_evaluator)
             cfg.test_evaluator.append(dump_metric)
         elif isinstance(cfg.test_evaluator, dict):
-            if 'metrics' in cfg.test_evaluator.keys():
+            if 'metrics' in cfg.test_evaluator:
                 cfg.test_evaluator['metrics'].append(dump_metric)
             else:
                 cfg.test_evaluator['metrics'] = [dump_metric]

--- a/tools/test.py
+++ b/tools/test.py
@@ -121,7 +121,7 @@ def main():
         if isinstance(cfg.test_evaluator, (list, tuple)):
             cfg.test_evaluator = list(cfg.test_evaluator)
             cfg.test_evaluator.append(dump_metric)
-        if isinstance(cfg.test_evaluator, dict):
+        elif isinstance(cfg.test_evaluator, dict):
             if 'metrics' in cfg.test_evaluator.keys():
                 cfg.test_evaluator['metrics'].append(dump_metric)
             else:


### PR DESCRIPTION
## Motivation

To improve the test tool, when testing model with tools/test.py and "--save-preds" option. 

## Modification
When the `test_evaluator` config is a dict and `--save-preds` is in `tools/test.py`'s option, the runner cannot correctly buid the evaluator.For example:
My config file
```python
test_evaluator = dict(
    type='MultiDatasetsEvaluator',
    metrics=[
        dict(
            type='WordMetric',
            mode=['exact', 'ignore_case', 'ignore_case_symbol']),
        dict(type='CharMetric')
    ],
    dataset_prefixes=None)
```
My test script
```console
python tools/test.py \
work_dirs/master_resnet31_12e.py \
work_dirs/best_ocr_rec_1_recog_char_f1_epoch_980.pth \
--save-preds
```
the `--save-preds` option will concat the evaluator with a `DumpResults` instance in a wrong way,the new evaluator is like:
```python
test_evaluator = [
dict(type='MultiDatasetsEvaluator',
    metrics=[
        dict(
            type='WordMetric',
            mode=['exact', 'ignore_case', 'ignore_case_symbol']),
        dict(type='CharMetric')
    ],
    dataset_prefixes=None),
dict(
    type='DumpResults',
    out_file_path='my_work_dir')
]
```
This new `test_evaluator ` cannot be built by program.

After updating the `tools/test.py`, using the same config and test scripts, the new `test_evaluator` will be:
```python
test_evaluator = [
dict(type='MultiDatasetsEvaluator',
    metrics=[
        dict(
            type='WordMetric',
            mode=['exact', 'ignore_case', 'ignore_case_symbol']),
        dict(type='CharMetric'),
        dict(
            type='DumpResults',
            out_file_path='my_work_dir')
    ],
    dataset_prefixes=None)
]
```
This new `test_evaluator ` can be built correctly by program.

## Checklist

**Before PR**:

- [x] I have read and followed the workflow indicated in the [CONTRIBUTING.md](https://github.com/open-mmlab/mmocr/blob/main/.github/CONTRIBUTING.md) to create this PR.
- [x] Pre-commit or linting tools indicated in [CONTRIBUTING.md](https://github.com/open-mmlab/mmocr/blob/main/.github/CONTRIBUTING.md) are used to fix the potential lint issues.
- [x] Bug fixes are covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] New functionalities are covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, including docstring or example tutorials.

**After PR**:

- [x] If the modification has potential influence on downstream or other related projects, this PR should be tested with some of those projects.
- [x] CLA has been signed and all committers have signed the CLA in this PR.
